### PR TITLE
feat(linter): interfaces should not be prefixed with I

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+	parser: '@typescript-eslint/parser',
 	extends: [
 		'eslint:recommended',
 		'plugin:@typescript-eslint/recommended',
@@ -32,6 +33,17 @@ module.exports = {
 			{
 				ignoreCase: true,
 				ignoreDeclarationSort: true,
+			},
+		],
+		'@typescript-eslint/naming-convention': [
+			'error',
+			{
+				selector: 'interface',
+				format: ['PascalCase'],
+				custom: {
+					regex: '^I[A-Z]',
+					match: false,
+				},
 			},
 		],
 	},


### PR DESCRIPTION
* Interfaces moeten niet met `I` geprefixed worden.