### PR TITLE
Bugfix/datepicker base styling

### DIFF
--- a/src/modules/shared/components/Datepicker/Datepicker.stories.tsx
+++ b/src/modules/shared/components/Datepicker/Datepicker.stories.tsx
@@ -1,13 +1,10 @@
-import {
-	Datepicker,
-	futureDatepicker,
-	historicDatepicker,
-	TextInput,
-} from '@meemoo/react-components';
+import { futureDatepicker, historicDatepicker, TextInput } from '@meemoo/react-components';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import React, { useState } from 'react';
 
 import { Icon } from '../Icon';
+
+import Datepicker from './Datepicker';
 
 export default {
 	title: 'Components/Datepicker',

--- a/src/modules/shared/components/Datepicker/Datepicker.tsx
+++ b/src/modules/shared/components/Datepicker/Datepicker.tsx
@@ -1,0 +1,9 @@
+import { Datepicker as Base, DatepickerProps } from '@meemoo/react-components';
+import { FC } from 'react';
+
+// This component only wraps in the styling
+import 'react-datepicker/dist/react-datepicker.min.css';
+
+const Datepicker: FC<DatepickerProps> = (props) => <Base {...props} />;
+
+export default Datepicker;

--- a/src/modules/shared/components/Datepicker/index.ts
+++ b/src/modules/shared/components/Datepicker/index.ts
@@ -1,0 +1,1 @@
+export { default as Datepicker } from './Datepicker';

--- a/src/modules/shared/components/Timepicker/Timepicker.stories.tsx
+++ b/src/modules/shared/components/Timepicker/Timepicker.stories.tsx
@@ -1,8 +1,10 @@
-import { futureTimepicker, TextInput, timepicker, Timepicker } from '@meemoo/react-components';
+import { futureTimepicker, TextInput, timepicker } from '@meemoo/react-components';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import React, { useState } from 'react';
 
 import { Icon } from '../Icon';
+
+import Timepicker from './Timepicker';
 
 export default {
 	title: 'Components/Timepicker',

--- a/src/modules/shared/components/Timepicker/Timepicker.tsx
+++ b/src/modules/shared/components/Timepicker/Timepicker.tsx
@@ -1,0 +1,9 @@
+import { Timepicker as Base, TimepickerProps } from '@meemoo/react-components';
+import { FC } from 'react';
+
+// This component only wraps in the styling
+import 'react-datepicker/dist/react-datepicker.min.css';
+
+const Timepicker: FC<TimepickerProps> = (props) => <Base {...props} />;
+
+export default Timepicker;

--- a/src/modules/shared/components/Timepicker/index.ts
+++ b/src/modules/shared/components/Timepicker/index.ts
@@ -1,0 +1,1 @@
+export { default as Timepicker } from './Timepicker';

--- a/src/styles/components/_datepicker.scss
+++ b/src/styles/components/_datepicker.scss
@@ -37,12 +37,18 @@ $datepicker-border-color: $zinc;
 		line-height: $line-height-lg;
 
 		&-popper {
-			padding-bottom: 0;
-			padding-top: 0;
 			margin-top: -1px;
 			border-top: 1px solid $datepicker-border-color;
 			overflow-x: scroll;
 			max-width: 100%;
+
+			&[data-placement^="bottom"] {
+				padding-top: 0;
+			}
+
+			&[data-placement^="top"] {
+				padding-bottom: 0;
+			}
 		}
 	}
 


### PR DESCRIPTION
- Improved minor scss
- Imported minified css from node_modules, note that the `.module.css` files were throwing syntax errors upon inclusion hence the plain `.css` file.