### PR TITLE
feat(arc-294): search media items using elasticsearch endpoint

### DIFF
--- a/scripts/path-aliases.js
+++ b/scripts/path-aliases.js
@@ -6,7 +6,8 @@ const pathAliases = [
 	'i18n',
 	'navigation',
 	'reading-room',
-	'shared'
+	'media',
+	'shared',
 ];
 
 module.exports = pathAliases;

--- a/src/modules/media/hooks/get-media-objects.ts
+++ b/src/modules/media/hooks/get-media-objects.ts
@@ -1,0 +1,22 @@
+import { useQuery } from 'react-query';
+import { UseQueryResult } from 'react-query/types/react/types';
+
+import { QUERY_KEYS } from '@shared/const/query-keys';
+import { ApiResponseWrapper, ElasticsearchResponse } from '@shared/types/api';
+
+import { mediaService } from '../services/media';
+import { MediaInfo } from '../types';
+
+export function useGetMediaObjects(
+	filters:
+		| {
+				query: string | undefined;
+		  }
+		| undefined,
+	from: number,
+	size: number
+): UseQueryResult<ApiResponseWrapper<MediaInfo>> {
+	return useQuery([QUERY_KEYS.getMediaObjects, { filters, from, size }], () =>
+		mediaService.getAll(filters, from, size)
+	);
+}

--- a/src/modules/media/services/index.ts
+++ b/src/modules/media/services/index.ts
@@ -1,0 +1,1 @@
+export * from './media';

--- a/src/modules/media/services/media/index.ts
+++ b/src/modules/media/services/media/index.ts
@@ -1,0 +1,1 @@
+export * from './media.service';

--- a/src/modules/media/services/media/media.service.const.ts
+++ b/src/modules/media/services/media/media.service.const.ts
@@ -1,0 +1,1 @@
+export const MEDIA_SERVICE_BASE_URL = '/api/proxy/media';

--- a/src/modules/media/services/media/media.service.ts
+++ b/src/modules/media/services/media/media.service.ts
@@ -1,0 +1,33 @@
+import { ApiService } from '@shared/services';
+import { ApiResponseWrapper, ElasticsearchResponse } from '@shared/types/api';
+
+import { MediaInfo, MediaSearchFilters } from '../../types';
+
+import { MEDIA_SERVICE_BASE_URL } from './media.service.const';
+
+class MediaService extends ApiService {
+	public async getAll(
+		filters: MediaSearchFilters = {},
+		from = 0,
+		size = 20
+	): Promise<ApiResponseWrapper<MediaInfo>> {
+		const parsed = (await this.api
+			.post('', {
+				body: JSON.stringify({
+					filters,
+					size,
+					from,
+				}),
+			})
+			.json()) as ElasticsearchResponse<MediaInfo>;
+		return {
+			items: parsed?.hits?.hits.map((item) => item._source),
+			total: parsed?.hits?.total?.value,
+			size: size,
+			page: Math.floor(from / size),
+			pages: Math.ceil((parsed?.hits?.total?.value || 0) / size),
+		};
+	}
+}
+
+export const mediaService = new MediaService(MEDIA_SERVICE_BASE_URL);

--- a/src/modules/media/types/index.ts
+++ b/src/modules/media/types/index.ts
@@ -1,0 +1,31 @@
+export interface MediaInfo {
+	schema_in_language: any;
+	dcterms_available: string;
+	schema_creator?: {
+		Archiefvormer?: string[];
+		productionCompany?: string[];
+		Maker?: string[];
+	};
+	schema_identifier: string;
+	schema_description?: string;
+	schema_publisher?: {
+		Publisher: string[];
+	};
+	schema_duration: string;
+	schema_abstract?: string;
+	premis_identifier: string;
+	schema_genre?: string;
+	schema_date_published?: string;
+	schema_license?: string[];
+	schema_date_created?: string;
+	schema_contributor: any;
+	schema_maintainer: {
+		schema_identifier: string;
+	}[];
+	dcterms_format: 'video' | 'audio' | null;
+	schema_name: string;
+}
+
+export class MediaSearchFilters {
+	query?: string;
+}

--- a/src/modules/media/utils/index.ts
+++ b/src/modules/media/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './map-filters';

--- a/src/modules/media/utils/map-filters/index.ts
+++ b/src/modules/media/utils/map-filters/index.ts
@@ -1,0 +1,1 @@
+export * from './map-filters';

--- a/src/modules/media/utils/map-filters/map-filters.test.tsx
+++ b/src/modules/media/utils/map-filters/map-filters.test.tsx
@@ -1,0 +1,30 @@
+import { mapFilters } from './map-filters';
+
+describe('Utils', () => {
+	describe('mapFilters()', () => {
+		it('should map search query', () => {
+			const query = {
+				search: ['test1', 'test2'],
+				mediaType: '',
+				start: 0,
+			};
+			const filters = mapFilters(query);
+
+			expect(filters).toHaveLength(query.search.length);
+			expect(filters[0].value).toBe(query.search[0]);
+		});
+
+		it('Should filter out falsey search values', () => {
+			const value = 'test';
+			const query = {
+				search: [null, value],
+				mediaType: '',
+				start: 0,
+			};
+			const filters = mapFilters(query);
+
+			expect(filters).toHaveLength(1);
+			expect(filters[0].value).toBe(value);
+		});
+	});
+});

--- a/src/modules/media/utils/map-filters/map-filters.tsx
+++ b/src/modules/media/utils/map-filters/map-filters.tsx
@@ -1,0 +1,23 @@
+import { TagInfo } from '@meemoo/react-components';
+import { i18n } from 'next-i18next';
+import { DecodedValueMap } from 'use-query-params';
+
+import { READING_ROOM_QUERY_PARAM_CONFIG } from '@reading-room/const';
+
+export const mapFilters = (
+	query: DecodedValueMap<Pick<typeof READING_ROOM_QUERY_PARAM_CONFIG, 'search'>>
+): TagInfo[] => {
+	const searchFilters = (query.search ?? [])
+		.filter((keyword) => !!keyword)
+		.map((keyword) => ({
+			label: (
+				<span>
+					{i18n?.t('modules/reading-room/utils/map-filters/map-filters___trefwoord')}:{' '}
+					<strong>{keyword}</strong>
+				</span>
+			),
+			value: keyword as string,
+		}));
+
+	return searchFilters;
+};

--- a/src/modules/navigation/components/Navigation/NavigationDropdown/NavigationDropdown.tsx
+++ b/src/modules/navigation/components/Navigation/NavigationDropdown/NavigationDropdown.tsx
@@ -38,8 +38,7 @@ const NavigationDropdown: FC<NavigationDropdownProps> = ({
 							{typeof item.node === 'function'
 								? item.node({ closeDropdowns: () => onClose?.() })
 								: item.node}
-							{item.children &&
-								renderChildrenRecursively(item.children, (layer += 1))}
+							{item.children && renderChildrenRecursively(item.children, layer + 1)}
 						</div>
 					);
 				})}

--- a/src/modules/reading-room/components/FilterMenu/FilterMenu.types.ts
+++ b/src/modules/reading-room/components/FilterMenu/FilterMenu.types.ts
@@ -29,7 +29,7 @@ export interface FilterMenuFilterOption {
 	id: string;
 	icon?: IconProps['name'];
 	label: string;
-	form: () => ReactElement | null;
+	form?: () => ReactElement | null; // TODO make form not optional
 }
 
 export type OnFilterMenuSortClick = (key: ReadingRoomSort, order?: SortOrder) => void;

--- a/src/modules/reading-room/hooks/get-reading-rooms.ts
+++ b/src/modules/reading-room/hooks/get-reading-rooms.ts
@@ -2,8 +2,9 @@ import { useQuery } from 'react-query';
 import { UseQueryResult } from 'react-query/types/react/types';
 
 import { readingRoomService } from '@reading-room/services';
-import { ApiResponseWrapper, ReadingRoomInfo } from '@reading-room/types';
+import { ReadingRoomInfo } from '@reading-room/types';
 import { QUERY_KEYS } from '@shared/const/query-keys';
+import { ApiResponseWrapper } from '@shared/types/api';
 
 export function useGetReadingRooms(
 	searchInput: string | undefined,

--- a/src/modules/reading-room/services/reading-room/reading-room.service.ts
+++ b/src/modules/reading-room/services/reading-room/reading-room.service.ts
@@ -1,7 +1,8 @@
 import { stringifyUrl } from 'query-string';
 
-import { ApiResponseWrapper, ReadingRoomInfo } from '@reading-room/types';
+import { ReadingRoomInfo } from '@reading-room/types';
 import { ApiService } from '@shared/services';
+import { ApiResponseWrapper } from '@shared/types/api';
 
 import { READING_ROOM_SERVICE_BASE_URL } from './reading-room.service.const';
 

--- a/src/modules/reading-room/types/index.ts
+++ b/src/modules/reading-room/types/index.ts
@@ -14,14 +14,6 @@ export interface DefaultFilterFormProps {
 	name: string;
 }
 
-export interface ApiResponseWrapper<T> {
-	items: T[];
-	total: number;
-	pages: number;
-	page: number;
-	size: number;
-}
-
 export interface ReadingRoomInfo {
 	id: string;
 	maintainerId: string;

--- a/src/modules/shared/components/MediaCard/MediaCard.types.ts
+++ b/src/modules/shared/components/MediaCard/MediaCard.types.ts
@@ -7,6 +7,6 @@ export interface MediaCardProps {
 	title?: string;
 	preview?: string;
 	type?: 'video' | 'audio';
-	view: MediaCardViewMode;
+	view?: MediaCardViewMode;
 	keywords?: string[];
 }

--- a/src/modules/shared/const/query-keys.ts
+++ b/src/modules/shared/const/query-keys.ts
@@ -1,3 +1,4 @@
 export enum QUERY_KEYS {
 	getReadingRooms = 'getReadingRooms',
+	getMediaObjects = 'getMediaObjects',
 }

--- a/src/modules/shared/services/api-service/api.service.ts
+++ b/src/modules/shared/services/api-service/api.service.ts
@@ -6,6 +6,11 @@ export abstract class ApiService {
 
 	constructor(baseUrl: string) {
 		this.baseUrl = baseUrl;
-		this.api = ky.create({ prefixUrl: this.baseUrl });
+		this.api = ky.create({
+			prefixUrl: this.baseUrl,
+			headers: {
+				'content-type': 'application/json',
+			},
+		});
 	}
 }

--- a/src/modules/shared/types/api.ts
+++ b/src/modules/shared/types/api.ts
@@ -1,0 +1,32 @@
+export interface ElasticsearchResponse<T> {
+	took: number;
+	timed_out: boolean;
+	_shards: {
+		total: number;
+		successful: number;
+		skipped: number;
+		failed: number;
+	};
+	hits: {
+		total: {
+			value: number;
+			relation: string;
+		};
+		max_score: number;
+		hits: {
+			_index: string;
+			_type: string;
+			_id: string;
+			_score: number;
+			_source: T;
+		}[];
+	};
+}
+
+export interface ApiResponseWrapper<T> {
+	items: T[];
+	total: number;
+	pages: number;
+	page: number;
+	size: number;
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,6 +12,7 @@ import { RequestAccessBlade } from '@home/components';
 import { HOME_QUERY_PARAM_CONFIG } from '@home/const';
 import { withI18n } from '@i18n/wrappers';
 import { useGetReadingRooms } from '@reading-room/hooks/get-reading-rooms';
+import { ReadingRoomInfo } from '@reading-room/types';
 import {
 	Hero,
 	ReadingRoomCardList,
@@ -148,20 +149,22 @@ const Home: NextPage = () => {
 				{!isLoadingReadingRooms && readingRoomInfo?.items?.length && (
 					<ReadingRoomCardList
 						className="u-mb-64"
-						items={(readingRoomInfo?.items || []).map((room): ReadingRoomCardProps => {
-							return {
-								room: {
-									color: room.color || undefined,
-									description: room.description || undefined,
-									id: room.id,
-									image: room.image || undefined,
-									name: room.name,
-									logo: room.logo,
-								},
-								type: ReadingRoomCardType.noAccess, // TODO change this based on current logged in user
-								onAccessRequest: onRequestAccess,
-							};
-						})}
+						items={(readingRoomInfo?.items || []).map(
+							(room: ReadingRoomInfo): ReadingRoomCardProps => {
+								return {
+									room: {
+										color: room.color || undefined,
+										description: room.description || undefined,
+										id: room.id,
+										image: room.image || undefined,
+										name: room.name,
+										logo: room.logo,
+									},
+									type: ReadingRoomCardType.noAccess, // TODO change this based on current logged in user
+									onAccessRequest: onRequestAccess,
+								};
+							}
+						)}
 						limit={!areAllReadingRoomsVisible}
 					/>
 				)}

--- a/src/pages/leeszaal/[readingRoomSlug]/index.tsx
+++ b/src/pages/leeszaal/[readingRoomSlug]/index.tsx
@@ -8,6 +8,7 @@ import { useQueryParams } from 'use-query-params';
 
 import { withAuth } from '@auth/wrappers/with-auth';
 import { withI18n } from '@i18n/wrappers';
+import { useGetMediaObjects } from '@media/hooks/get-media-objects';
 import { FilterMenu, ReadingRoomNavigation } from '@reading-room/components';
 import {
 	READING_ROOM_FILTERS,
@@ -36,9 +37,6 @@ import { WindowSizeContext } from '@shared/context/WindowSizeContext';
 import { useWindowSize } from '@shared/hooks';
 import { SortOrder } from '@shared/types';
 import { createPageTitle } from '@shared/utils';
-
-import { useGetMediaObjects } from '../../../modules/media/hooks/get-media-objects';
-import { MediaInfo } from '../../../modules/media/types';
 
 const ReadingRoomPage: NextPage = () => {
 	// State

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
       "@i18n/*": ["modules/i18n/*"],
       "@navigation/*": ["modules/navigation/*"],
       "@reading-room/*": ["modules/reading-room/*"],
+      "@media/*": ["modules/media/*"],
       "@shared/*": ["modules/shared/*"]
     },
     "target": "es5",


### PR DESCRIPTION
before the user searches:
![image](https://user-images.githubusercontent.com/1710840/153223798-64c6aa20-c077-4e26-b339-1a565d131d19.png)

when they search:
![image](https://user-images.githubusercontent.com/1710840/153223836-7170b285-072d-4b99-8a67-b2c0daa4b4f7.png)

when they switch tabs it currently shows all items, since we cannot search by media type yet:
![image](https://user-images.githubusercontent.com/1710840/153223906-856a0e65-ac68-496c-a031-163ad9d6c73d.png)

