### PR TITLE
fix(env-vars): fix env vars for tst

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,11 +1,11 @@
 # ENVIRONMENT
 NODE_ENV=local
 
-# SERVER
+# CLIENT PORT
 PORT=3200
 
-# CLIENT (Prefix with `NEXT_PUBLIC_`)
-NEXT_PUBLIC_ORIGIN=http://localhost:${PORT}
+# CLIENT URL
+CLIENT_URL=http://localhost:${PORT}
 
 # Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry
@@ -17,3 +17,6 @@ PROXY_URL=http://localhost:3100
 
 # Full path to your local hetarchief-proxy repository; used to copy the whitelisted graphql queries
 PROXY_PATH=/path/to/hetarchief-proxy
+
+# Enable debugger tools for react and enable source maps for javascript
+DEBUG_TOOLS=true

--- a/next.config.js
+++ b/next.config.js
@@ -29,11 +29,13 @@ module.exports = withTM({
 	images: {
 		domains: ['assets.viaa.be'],
 	},
+	productionBrowserSourceMaps: process.env.DEBUG_TOOLS === 'true',
 	publicRuntimeConfig: {
+		NEXT_TELEMETRY_DISABLED: process.env.NEXT_TELEMETRY_DISABLED,
 		NODE_ENV: process.env.NODE_ENV,
 		PORT: process.env.PORT,
-		NEXT_PUBLIC_ORIGIN: process.env.NEXT_PUBLIC_ORIGIN,
-		NEXT_TELEMETRY_DISABLED: process.env.NEXT_TELEMETRY_DISABLED,
+		CLIENT_URL: process.env.CLIENT_URL,
 		PROXY_URL: process.env.PROXY_URL,
+		DEBUG_TOOLS: process.env.DEBUG_TOOLS,
 	},
 });

--- a/src/modules/auth/services/auth-service/auth.service.ts
+++ b/src/modules/auth/services/auth-service/auth.service.ts
@@ -2,7 +2,6 @@ import { Options } from 'ky/distribution/types/options';
 import getConfig from 'next/config';
 import { StringifiableRecord, stringifyUrl } from 'query-string';
 
-import { config } from '@config/const';
 import { ApiService } from '@shared/services';
 
 import { CheckLoginResponse } from './auth.service.types';
@@ -16,7 +15,7 @@ export class AuthService extends ApiService {
 
 	public static redirectToLogin(query: StringifiableRecord): void {
 		const returnToUrl = stringifyUrl({
-			url: config.public.origin,
+			url: publicRuntimeConfig.CLIENT_URL,
 			query,
 		});
 
@@ -29,7 +28,7 @@ export class AuthService extends ApiService {
 	}
 
 	public static logout(): void {
-		const returnToUrl = config.public.origin;
+		const returnToUrl = publicRuntimeConfig.CLIENT_URL;
 
 		window.location.href = stringifyUrl({
 			url: `${publicRuntimeConfig.PROXY_URL}/auth/global-logout`,

--- a/src/modules/config/const/index.ts
+++ b/src/modules/config/const/index.ts
@@ -1,5 +1,0 @@
-export const config = Object.freeze({
-	public: {
-		origin: process.env.NEXT_PUBLIC_ORIGIN,
-	},
-} as const);

--- a/src/modules/shared/store/store.ts
+++ b/src/modules/shared/store/store.ts
@@ -13,7 +13,7 @@ export const makeStore = () =>
 			[uiSlice.name]: uiSlice.reducer,
 			[userSlice.name]: userSlice.reducer,
 		},
-		devTools: process.env.NODE_ENV !== 'production',
+		devTools: process.env.DEBUG_TOOLS === 'true',
 	});
 
 export const wrapper = createWrapper<AppStore>(makeStore);

--- a/src/modules/shared/types/global.d.ts
+++ b/src/modules/shared/types/global.d.ts
@@ -1,26 +1,16 @@
 /// <reference types="next" />
 
 // Extend the NodeJS namespace with Next.js-defined properties
-declare namespace NodeJS {
-	interface ProcessEnv {
-		readonly NODE_ENV: 'development' | 'production' | 'test';
-		readonly NEXT_PUBLIC_ORIGIN: 'string';
-		readonly PORT: 'string';
-		readonly PROXY_URL: 'string';
+declare global {
+	namespace NodeJS {
+		interface ProcessEnv {
+			readonly NODE_ENV: 'development' | 'production' | 'test';
+			readonly CLIENT_URL: string;
+			readonly PORT: string;
+			readonly PROXY_URL: string;
+			readonly DEBUG_TOOLS: 'true' | 'false';
+		}
 	}
 }
 
-interface Window {
-	_ENV_: {
-		NODE_ENV: string;
-		PORT: string;
-		NEXT_PUBLIC_ORIGIN: string;
-		NEXT_TELEMETRY_DISABLED: string;
-		PROXY_URL: string;
-		PROXY_PATH: string;
-	};
-	APP_INFO: {
-		version: string;
-		mode: 'development' | 'production' | 'test';
-	};
-}
+export {};


### PR DESCRIPTION
- Fix missing origin env var (get it through publicRuntimeConfig instead of process.env)
- renamed NEXT_PUBLIC_ORIGIN to CLIENT_URL (more in line with PROXY_URL)
- Switch production check to BUILD_TOOLS === 'true' check (in case we ever want to enable build tools on production)
- Add better type checking for process.env, so we don't need to mirror env vars in a separate config.ts file