### PR TITLE
feat(mobile): prevent mobile browsers from inflating text

### DIFF
--- a/src/styles/base/_reset.scss
+++ b/src/styles/base/_reset.scss
@@ -1,3 +1,10 @@
+html {
+	// Prevent mobile browsers from inflating text
+	// https://developer.mozilla.org/en-US/docs/Web/CSS/text-size-adjust
+
+	text-size-adjust: none;
+  }
+
 h1,
 h2,
 h3,


### PR DESCRIPTION
https://kilianvalkhof.com/2022/css-html/your-css-reset-needs-text-size-adjust-probably/
https://developer.mozilla.org/en-US/docs/Web/CSS/text-size-adjust

Some mobile browsers enlarge the default text to improve readability. This was relevant when web was not optimised for mobile. This stops that default behaviour and prevents an inflated look in most mobile browsers.