### PR TITLE
fix(navigation-header): move separator line up 1 pixel

### DIFF
--- a/src/modules/navigation/components/Navigation/Navigation.module.scss
+++ b/src/modules/navigation/components/Navigation/Navigation.module.scss
@@ -64,7 +64,7 @@ $c-navigation-dropdown-item-spacer: 1.2rem;
 		content: "";
 		position: absolute;
 		z-index: get-z-layer("foreground");
-		bottom: -1px;
+		bottom: 0;
 		left: 2rem;
 		right: 2rem;
 		height: 1px;


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/1710840/154249668-30c3c330-a6c9-4709-a9c8-5481eb96168f.png)

after:
![image](https://user-images.githubusercontent.com/1710840/154249677-f9e1275e-f413-4f87-b02f-8894b930123a.png)
