### PR TITLE
feat(arc-392): hide divider when user has no access to any reading rooms

### DIFF
--- a/src/modules/navigation/components/Navigation/Navigation.consts.tsx
+++ b/src/modules/navigation/components/Navigation/Navigation.consts.tsx
@@ -75,7 +75,7 @@ export const getNavigationItemsLeft = (
 					className: dropdownCls(['u-display-none', 'u-display-block:md']),
 				}),
 				id: 'alle leeszalen',
-				hasDivider: 'md',
+				hasDivider: accessibleReadingRooms.length > 0 ? 'md' : undefined,
 			},
 			...accessibleReadingRooms.map(
 				(readingRoom: ReadingRoomInfo): NavigationItem => ({


### PR DESCRIPTION
before and after:
![image](https://user-images.githubusercontent.com/1710840/159728826-1ddcd983-e6c4-481c-8c24-bed5b752eab2.png)
