### PR TITLE
Bugfix/object detail 2

### DIFF
--- a/src/modules/media/const/index.tsx
+++ b/src/modules/media/const/index.tsx
@@ -4,7 +4,7 @@ import { i18n } from 'next-i18next';
 import { MetadataItem, ObjectPlaceholderProps } from '@media/components';
 import { objectPlaceholderMock } from '@media/components/ObjectPlaceholder/__mocks__/object-placeholder';
 import { Media, MediaActions, ObjectDetailTabs } from '@media/types';
-import { mapArrayToMetadataData, mapKeywordsToTagList, mapObjectToMetadata } from '@media/utils';
+import { mapArrayToMetadataData, mapObjectToMetadata } from '@media/utils';
 import { Icon } from '@shared/components';
 import { MediaTypes } from '@shared/types';
 
@@ -102,50 +102,15 @@ export const OBJECT_DETAIL_TABS = (mediaType: MediaTypes): TabProps[] => [
 export const MEDIA_ACTIONS = (): DynamicActionMenuProps => ({
 	actions: [
 		{
-			label: i18n?.t('modules/media/const/index___quotes') ?? '',
-			iconName: 'quotes',
-			id: MediaActions.Quotes,
-			ariaLabel: 'copies quotes',
-			tooltip: i18n?.t('modules/media/const/index___quotes') ?? '',
-		},
-		{
-			label: i18n?.t('modules/media/const/index___description') ?? '',
-			iconName: 'description',
-			id: MediaActions.Description,
-			ariaLabel: 'shows description',
-			tooltip: i18n?.t('modules/media/const/index___description') ?? '',
-		},
-		{
 			label: i18n?.t('modules/media/const/index___bookmark') ?? '',
 			iconName: 'bookmark',
 			id: MediaActions.Bookmark,
 			ariaLabel: 'bookmarks item',
 			tooltip: i18n?.t('modules/media/const/index___bookmark') ?? '',
 		},
-		{
-			label: i18n?.t('modules/media/const/index___contact') ?? '',
-			iconName: 'contact',
-			id: MediaActions.Contact,
-			ariaLabel: 'contact reading room',
-			tooltip: i18n?.t('modules/media/const/index___contact') ?? '',
-		},
-		{
-			label: i18n?.t('modules/media/const/index___calendar') ?? '',
-			iconName: 'calendar',
-			id: MediaActions.Calendar,
-			ariaLabel: 'copy date',
-			tooltip: i18n?.t('modules/media/const/index___calendar') ?? '',
-		},
-		{
-			label: i18n?.t('modules/media/const/index___related-objects') ?? '',
-			iconName: 'related-objects',
-			id: MediaActions.RelatedObjects,
-			ariaLabel: 'access related objects',
-			tooltip: i18n?.t('modules/media/const/index___related-objects') ?? '',
-		},
 	],
 	limit: 2,
-	onClickAction: (id) => console.log(id),
+	onClickAction: () => null,
 });
 
 /**

--- a/src/modules/media/const/index.tsx
+++ b/src/modules/media/const/index.tsx
@@ -241,10 +241,11 @@ export const METADATA_FIELDS = (mediaInfo: Media): MetadataItem[] =>
 			title: i18n?.t('modules/media/const/index___tijdsperiode-van-de-inhoud') ?? '',
 			data: mapArrayToMetadataData(mediaInfo.temporal),
 		},
-		{
-			title: i18n?.t('modules/media/const/index___trefwoorden') ?? '',
-			data: mapKeywordsToTagList(mediaInfo.keywords),
-		},
+		// In second metadata component
+		// {
+		// 	title: i18n?.t('modules/media/const/index___trefwoorden') ?? '',
+		// 	data: mapKeywordsToTagList(mediaInfo.keywords),
+		// },
 		{
 			title: i18n?.t('modules/media/const/index___taal') ?? '',
 			data: mapArrayToMetadataData(mediaInfo.inLanguage),

--- a/src/modules/reading-room/components/ReadingRoomNavigation/ReadingRoomNavigation.tsx
+++ b/src/modules/reading-room/components/ReadingRoomNavigation/ReadingRoomNavigation.tsx
@@ -15,6 +15,7 @@ import { ReadingRoomNavigationProps } from './ReadingRoomNavigation.types';
 
 const ReadingRoomNavigation: FC<ReadingRoomNavigationProps> = ({
 	title,
+	backLink = '/',
 	showAccessEndDate,
 	className,
 }) => {
@@ -31,7 +32,7 @@ const ReadingRoomNavigation: FC<ReadingRoomNavigationProps> = ({
 	return (
 		<Navigation contextual className={className} showBorder={showBorder}>
 			<Navigation.Left placement="left">
-				<Link href="/" passHref={true}>
+				<Link href={backLink} passHref={true}>
 					<a>
 						<Button
 							icon={<Icon name="arrow-left" />}

--- a/src/modules/reading-room/components/ReadingRoomNavigation/ReadingRoomNavigation.types.ts
+++ b/src/modules/reading-room/components/ReadingRoomNavigation/ReadingRoomNavigation.types.ts
@@ -2,6 +2,7 @@ import { DefaultComponentProps } from '@shared/types';
 
 export interface ReadingRoomNavigationProps extends DefaultComponentProps {
 	title?: string;
+	backLink?: string;
 	showAccessEndDate?: string;
 	showBorder: boolean;
 }

--- a/src/modules/shared/hooks/use-history/index.ts
+++ b/src/modules/shared/hooks/use-history/index.ts
@@ -1,0 +1,2 @@
+export { default as useHistory } from './use-history';
+export * from './use-history.types';

--- a/src/modules/shared/hooks/use-history/use-history.test.tsx
+++ b/src/modules/shared/hooks/use-history/use-history.test.tsx
@@ -10,15 +10,16 @@ jest.mock('react-redux', () => ({
 
 describe('Hooks', () => {
 	describe('useHistory', () => {
-		it('Should set isStickyLayout in the store', () => {
+		it('Should set history in the store', () => {
 			mockDispatch = jest.fn();
-			renderHook(() => useHistory());
+			const path = '/';
+			renderHook(() => useHistory(path, []));
 
 			expect(mockDispatch).toHaveBeenCalled();
 			expect(mockDispatch).toHaveBeenCalledTimes(1);
 			expect(mockDispatch).toHaveBeenCalledWith({
-				payload: true,
-				type: 'ui/setIsStickyLayout',
+				payload: [undefined, path],
+				type: 'history/setHistory',
 			});
 		});
 	});

--- a/src/modules/shared/hooks/use-history/use-history.test.tsx
+++ b/src/modules/shared/hooks/use-history/use-history.test.tsx
@@ -1,0 +1,25 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import useHistory from './use-history';
+
+let mockDispatch = jest.fn();
+jest.mock('react-redux', () => ({
+	useSelector: jest.fn(),
+	useDispatch: () => mockDispatch,
+}));
+
+describe('Hooks', () => {
+	describe('useHistory', () => {
+		it('Should set isStickyLayout in the store', () => {
+			mockDispatch = jest.fn();
+			renderHook(() => useHistory());
+
+			expect(mockDispatch).toHaveBeenCalled();
+			expect(mockDispatch).toHaveBeenCalledTimes(1);
+			expect(mockDispatch).toHaveBeenCalledWith({
+				payload: true,
+				type: 'ui/setIsStickyLayout',
+			});
+		});
+	});
+});

--- a/src/modules/shared/hooks/use-history/use-history.ts
+++ b/src/modules/shared/hooks/use-history/use-history.ts
@@ -1,25 +1,24 @@
-import { useRouter } from 'next/router';
 import { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
-import { selectHistory, setHistory } from '@shared/store/history';
+import { setHistory } from '@shared/store/history';
 
 import { UseHistory } from './use-history.types';
 
-const useHistory: UseHistory = () => {
+const useHistory: UseHistory = (path, history) => {
 	const dispatch = useDispatch();
-	const { asPath } = useRouter();
-	const history = useSelector(selectHistory);
 
 	useEffect(() => {
+		const newHistory = [history[history.length - 1], path];
+
 		// Only save previous link
-		dispatch(setHistory([history[history.length - 1], asPath]));
+		dispatch(setHistory(newHistory));
 
 		return () => {
-			dispatch(setHistory([history[history.length - 1], asPath]));
+			dispatch(setHistory(newHistory));
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [asPath]);
+	}, [path, dispatch]);
 };
 
 export default useHistory;

--- a/src/modules/shared/hooks/use-history/use-history.ts
+++ b/src/modules/shared/hooks/use-history/use-history.ts
@@ -1,0 +1,25 @@
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { selectHistory, setHistory } from '@shared/store/history';
+
+import { UseHistory } from './use-history.types';
+
+const useHistory: UseHistory = () => {
+	const dispatch = useDispatch();
+	const { asPath } = useRouter();
+	const history = useSelector(selectHistory);
+
+	useEffect(() => {
+		// Only save previous link
+		dispatch(setHistory([history[history.length - 1], asPath]));
+
+		return () => {
+			dispatch(setHistory([history[history.length - 1], asPath]));
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [asPath]);
+};
+
+export default useHistory;

--- a/src/modules/shared/hooks/use-history/use-history.types.ts
+++ b/src/modules/shared/hooks/use-history/use-history.types.ts
@@ -1,1 +1,1 @@
-export type UseHistory = () => void;
+export type UseHistory = (path: string, history: string[]) => void;

--- a/src/modules/shared/hooks/use-history/use-history.types.ts
+++ b/src/modules/shared/hooks/use-history/use-history.types.ts
@@ -1,0 +1,1 @@
+export type UseHistory = () => void;

--- a/src/modules/shared/layouts/AppLayout/AppLayout.tsx
+++ b/src/modules/shared/layouts/AppLayout/AppLayout.tsx
@@ -26,6 +26,7 @@ import { useHistory } from '@shared/hooks/use-history';
 import { useWindowSize } from '@shared/hooks/use-window-size';
 import { NotificationsService } from '@shared/services/notifications-service/notifications.service';
 import { useAppDispatch } from '@shared/store';
+import { selectHistory } from '@shared/store/history';
 import { getTosAction } from '@shared/store/tos/tos.slice';
 import {
 	selectHasUnreadNotifications,
@@ -51,8 +52,9 @@ const AppLayout: FC = ({ children }) => {
 	const windowSize = useWindowSize();
 	const showBorder = useSelector(selectShowNavigationBorder);
 	const { data: accessibleReadingRooms } = useGetAccessibleReadingRooms();
+	const history = useSelector(selectHistory);
 
-	useHistory();
+	useHistory(asPath, history);
 
 	const setNotificationsOpen = useCallback(
 		(show: boolean) => {

--- a/src/modules/shared/layouts/AppLayout/AppLayout.tsx
+++ b/src/modules/shared/layouts/AppLayout/AppLayout.tsx
@@ -22,6 +22,7 @@ import { useGetNotifications } from '@shared/components/NotificationCenter/hooks
 import { useMarkAllNotificationsAsRead } from '@shared/components/NotificationCenter/hooks/mark-all-notifications-as-read';
 import { useMarkOneNotificationsAsRead } from '@shared/components/NotificationCenter/hooks/mark-one-notifications-as-read';
 import { WindowSizeContext } from '@shared/context/WindowSizeContext';
+import { useHistory } from '@shared/hooks/use-history';
 import { useWindowSize } from '@shared/hooks/use-window-size';
 import { NotificationsService } from '@shared/services/notifications-service/notifications.service';
 import { useAppDispatch } from '@shared/store';
@@ -50,6 +51,8 @@ const AppLayout: FC = ({ children }) => {
 	const windowSize = useWindowSize();
 	const showBorder = useSelector(selectShowNavigationBorder);
 	const { data: accessibleReadingRooms } = useGetAccessibleReadingRooms();
+
+	useHistory();
 
 	const setNotificationsOpen = useCallback(
 		(show: boolean) => {

--- a/src/modules/shared/store/history/history.select.ts
+++ b/src/modules/shared/store/history/history.select.ts
@@ -2,4 +2,4 @@ import { AppState } from '../store.types';
 
 export const selectHistory = (state: AppState): string[] => state.history.history;
 export const selectPreviousUrl = (state: AppState): string | undefined =>
-	state.history.history[state.history.history.length - 2];
+	state.history && state.history.history[state.history.history.length - 2];

--- a/src/modules/shared/store/history/history.select.ts
+++ b/src/modules/shared/store/history/history.select.ts
@@ -1,0 +1,5 @@
+import { AppState } from '../store.types';
+
+export const selectHistory = (state: AppState): string[] => state.history.history;
+export const selectPreviousUrl = (state: AppState): string | undefined =>
+	state.history.history[state.history.history.length - 2];

--- a/src/modules/shared/store/history/history.slice.ts
+++ b/src/modules/shared/store/history/history.slice.ts
@@ -1,0 +1,19 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import { HistoryState } from './history.types';
+
+const initialState: HistoryState = {
+	history: [],
+};
+
+export const historySlice = createSlice({
+	name: 'history',
+	initialState,
+	reducers: {
+		setHistory(state, action: PayloadAction<string[]>) {
+			state.history = action.payload;
+		},
+	},
+});
+
+export const { setHistory } = historySlice.actions;

--- a/src/modules/shared/store/history/history.types.ts
+++ b/src/modules/shared/store/history/history.types.ts
@@ -1,0 +1,3 @@
+export interface HistoryState {
+	history: string[];
+}

--- a/src/modules/shared/store/history/index.ts
+++ b/src/modules/shared/store/history/index.ts
@@ -1,0 +1,3 @@
+export * from './history.select';
+export * from './history.slice';
+export * from './history.types';

--- a/src/modules/shared/store/store.ts
+++ b/src/modules/shared/store/store.ts
@@ -5,6 +5,7 @@ import { userSlice } from '@auth/store/user';
 import { mediaSlice } from '@shared/store/media';
 import { tosSlice } from '@shared/store/tos';
 
+import { historySlice } from './history';
 import { AppStore } from './store.types';
 import { uiSlice } from './ui';
 
@@ -16,6 +17,7 @@ export const makeStore = () =>
 			[userSlice.name]: userSlice.reducer,
 			[tosSlice.name]: tosSlice.reducer,
 			[mediaSlice.name]: mediaSlice.reducer,
+			[historySlice.name]: historySlice.reducer,
 		},
 		devTools: process.env.DEBUG_TOOLS === 'true',
 	});

--- a/src/pages/leeszaal/[readingRoomSlug]/[objectId]/index.tsx
+++ b/src/pages/leeszaal/[readingRoomSlug]/[objectId]/index.tsx
@@ -27,6 +27,7 @@ import {
 import { useGetMediaInfo } from '@media/hooks/get-media-info';
 import { useGetMediaTicketInfo } from '@media/hooks/get-media-ticket-url';
 import { MediaActions, MediaRepresentation, ObjectDetailTabs } from '@media/types';
+import { mapKeywordsToTagList } from '@media/utils';
 import { AddToCollectionBlade, ReadingRoomNavigation } from '@reading-room/components';
 import { Icon, Loading, ScrollableTabs, TabLabel } from '@shared/components';
 import { useElementSize } from '@shared/hooks/use-element-size';
@@ -382,6 +383,10 @@ const ObjectDetailPage: NextPage = () => {
 									<Metadata
 										className="u-px-32"
 										metadata={[
+											{
+												title: t('modules/media/const/index___trefwoorden'),
+												data: mapKeywordsToTagList(mediaInfo.keywords),
+											},
 											{
 												title: 'Ook interessant',
 												data: (

--- a/src/pages/leeszaal/[readingRoomSlug]/[objectId]/index.tsx
+++ b/src/pages/leeszaal/[readingRoomSlug]/[objectId]/index.tsx
@@ -12,7 +12,6 @@ import { useSelector } from 'react-redux';
 import { withAuth } from '@auth/wrappers/with-auth';
 import { withI18n } from '@i18n/wrappers';
 import { FragmentSlider } from '@media/components/FragmentSlider';
-import { fragmentSliderMock } from '@media/components/FragmentSlider/__mocks__/fragmentSlider';
 import { relatedObjectVideoMock } from '@media/components/RelatedObject/__mocks__/related-object';
 import {
 	FLOWPLAYER_FORMATS,
@@ -35,6 +34,7 @@ import { useHideFooter } from '@shared/hooks/use-hide-footer';
 import { useNavigationBorder } from '@shared/hooks/use-navigation-border';
 import { useStickyLayout } from '@shared/hooks/use-sticky-layout';
 import { useWindowSizeContext } from '@shared/hooks/use-window-size-context';
+import { selectPreviousUrl } from '@shared/store/history';
 import { selectShowNavigationBorder } from '@shared/store/ui';
 import { MediaTypes } from '@shared/types';
 import { asDate, createPageTitle, formatAccessDate } from '@shared/utils';
@@ -57,6 +57,7 @@ const ObjectDetailPage: NextPage = () => {
 	 */
 	const { t } = useTranslation();
 	const router = useRouter();
+	const previousUrl = useSelector(selectPreviousUrl);
 
 	// Internal state
 	const [activeTab, setActiveTab] = useState<string | number | null>(null);
@@ -260,6 +261,11 @@ const ObjectDetailPage: NextPage = () => {
 					className="p-object-detail__nav"
 					showBorder={showNavigationBorder}
 					title={mediaInfo?.maintainerName ?? ''}
+					backLink={
+						previousUrl?.startsWith('/leeszaal/')
+							? previousUrl
+							: `/leeszaal/${router.query.readingRoomSlug}`
+					}
 					showAccessEndDate={
 						accessEndDate
 							? t(

--- a/src/pages/leeszaal/[readingRoomSlug]/[objectId]/index.tsx
+++ b/src/pages/leeszaal/[readingRoomSlug]/[objectId]/index.tsx
@@ -256,6 +256,7 @@ const ObjectDetailPage: NextPage = () => {
 					<meta name="description" content="Object detail omschrijving" />
 				</Head>
 				<ReadingRoomNavigation
+					className="p-object-detail__nav"
 					showBorder={showNavigationBorder}
 					title={mediaInfo?.maintainerName ?? ''}
 					showAccessEndDate={


### PR DESCRIPTION
- 1px height difference on object detail
![image](https://user-images.githubusercontent.com/85545258/160832568-797e857f-b54b-4d90-8f9a-4fe2bb9630da.png)
- Trefwoorden blijven in één kolom op metadata view in object detail
- Object detail back button ([ARC-685](https://meemoo.atlassian.net/browse/ARC-685))
- Object detail media actions ([ARC-683](https://meemoo.atlassian.net/browse/ARC-683))