### PR TITLE
feat(arc-161): Add cookiebot script to head of page

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,13 +1,39 @@
 import { Head, Html, Main, NextScript } from 'next/document';
-import { ReactElement } from 'react';
+import React, { ReactElement } from 'react';
+
+// declare type DocumentFiles = {
+// 	sharedFiles: readonly string[];
+// 	pageFiles: readonly string[];
+// 	allFiles: readonly string[];
+// };
+
+class CustomHead extends Head {
+	// TODO use this if we encounter the blank screen because cookiebot keeps blocking essential scripts
+	// getScripts(files: DocumentFiles): ReactElement[] {
+	// 	const originalScripts = super.getScripts(files);
+	// 	return originalScripts.map((script) => {
+	// 		return React.cloneElement(script, {
+	// 			'data-cookieconsent': 'ignore',
+	// 		});
+	// 	});
+	// }
+}
 
 const Document = (): ReactElement => {
 	return (
 		<Html>
-			<Head>
+			<CustomHead>
 				{/* eslint-disable-next-line */}
-				<link rel="stylesheet" href="/flowplayer/style/flowplayer.css" />
-			</Head>
+				<script
+					id="Cookiebot"
+					src="https://consent.cookiebot.com/uc.js"
+					data-cbid="e17bca33-78a0-484e-a204-e05274a65598"
+					data-blockingmode="auto"
+					type="text/javascript"
+				/>
+				{/* eslint-disable-next-line */}
+				<link rel="stylesheet" href="/flowplayer/style/flowplayer.css" />,
+			</CustomHead>
 			<body>
 				<Main />
 				<NextScript />


### PR DESCRIPTION
Cookbot script is added in head section, but by default it doesn't load on localhost. We'll be able to see it working on TST and Maaike will be able to check which cookies the site is trying to set.

![image](https://user-images.githubusercontent.com/1710840/164238914-eb41557b-75ec-4b2f-9f3f-6f74d2bae35a.png)
