### PR TITLE
feat(arc-775): Add google tag manager script for QAS and PRD

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -29,9 +29,12 @@ TEST_ENDPOINT=https://bezoek-tst.private.cloud.meemoo.be
 TEST_ACCOUNT_USERNAME=
 TEST_ACCOUNT_PSSWORD=
 
-# Zendesk
-ZENDESK_KEY=
-
 # Flowplayer
 FLOW_PLAYER_TOKEN=
 FLOW_PLAYER_ID=
+
+# Zendesk
+ZENDESK_KEY=
+
+# Google tag manager, empty means: don't load gtm
+GOOGLE_TAG_MANAGER_ID=

--- a/next.config.js
+++ b/next.config.js
@@ -49,5 +49,6 @@ module.exports = withTM({
 		ZENDESK_KEY: process.env.ZENDESK_KEY,
 		FLOW_PLAYER_TOKEN: process.env.FLOW_PLAYER_TOKEN,
 		FLOW_PLAYER_ID: process.env.FLOW_PLAYER_ID,
+		GOOGLE_TAG_MANAGER_ID: process.env.GOOGLE_TAG_MANAGER_ID,
 	},
 });

--- a/src/__mocks__/next-config.ts
+++ b/src/__mocks__/next-config.ts
@@ -4,5 +4,6 @@ export default jest.mock('next/config', () => () => ({
 		PROXY_URL: '/proxy-url',
 		FLOW_PLAYER_TOKEN: 'my-flowplayer-token',
 		FLOW_PLAYER_ID: 'some-id',
+		GOOGLE_TAG_MANAGER_ID: 'GTM-MKDR4BQ',
 	},
 }));

--- a/src/modules/shared/layouts/AppLayout/AppLayout.tsx
+++ b/src/modules/shared/layouts/AppLayout/AppLayout.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import { i18n } from 'next-i18next';
+import getConfig from 'next/config';
 import { useRouter } from 'next/router';
 import Script from 'next/script';
 import { FC, useCallback, useEffect, useMemo } from 'react';
@@ -38,6 +39,8 @@ import {
 	setShowAuthModal,
 	setShowNotificationsCenter,
 } from '@shared/store/ui/';
+
+const { publicRuntimeConfig } = getConfig();
 
 const AppLayout: FC = ({ children }) => {
 	const dispatch = useAppDispatch();
@@ -125,6 +128,26 @@ const AppLayout: FC = ({ children }) => {
 				'l-app--sticky': sticky,
 			})}
 		>
+			{/* start Google Analytics */}
+			{publicRuntimeConfig.GOOGLE_TAG_MANAGER_ID && (
+				<>
+					<Script
+						src={`https://www.googletagmanager.com/gtag/js?id=${publicRuntimeConfig.GOOGLE_TAG_MANAGER_ID}`}
+						strategy="afterInteractive"
+					/>
+					<Script id="google-analytics" strategy="afterInteractive">
+						{`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){window.dataLayer.push(arguments);}
+          gtag('js', new Date());
+
+          gtag('config', '${publicRuntimeConfig.GOOGLE_TAG_MANAGER_ID}');
+        `}
+					</Script>
+				</>
+			)}
+			{/* end Google Analytics */}
+
 			{/* <!-- start Flowplayer imports --> */}
 			{/* Importing these in the root of the app so they are loaded when the flowplayer component starts to initialise */}
 			<Script strategy="beforeInteractive" src="/flowplayer/flowplayer.min.js" />

--- a/src/modules/shared/types/global.d.ts
+++ b/src/modules/shared/types/global.d.ts
@@ -13,6 +13,7 @@ declare global {
 			readonly ZENDESK_KEY: string;
 			readonly FLOW_PLAYER_TOKEN: string;
 			readonly FLOW_PLAYER_ID: string;
+			readonly GOOGLE_TAG_MANAGER_ID: string | null;
 		}
 	}
 }


### PR DESCRIPTION
* Add google tag manager script when GOOGLE_TAG_MANAGER_ID environment variable is set
* Add GOOGLE_TAG_MANAGER_ID env var to QAS and PRD environments

Used the nextjs way of setting scripts with deferred loading: https://nextjs.org/docs/messages/next-script-for-ga