### PR TITLE
feat(arc-487): redirect to 404 page if ie does not exist

### DIFF
--- a/src/modules/media/hooks/get-media-info.ts
+++ b/src/modules/media/hooks/get-media-info.ts
@@ -5,8 +5,13 @@ import { MediaService } from '@media/services';
 import { Media } from '@media/types';
 import { QUERY_KEYS } from '@shared/const/query-keys';
 
-export function useGetMediaInfo(id: string): UseQueryResult<Media> {
+export function useGetMediaInfo(
+	id: string,
+	onError: (err: unknown) => void
+): UseQueryResult<Media> {
 	return useQuery([QUERY_KEYS.getMediaInfo, { id }], () => MediaService.getById(id), {
 		keepPreviousData: false,
+		retry: false,
+		onError,
 	});
 }

--- a/src/pages/[slug]/[ie]/index.tsx
+++ b/src/pages/[slug]/[ie]/index.tsx
@@ -115,11 +115,16 @@ const ObjectDetailPage: NextPage = () => {
 	const metadataSize = useElementSize(metadataRef);
 
 	// Fetch object
+	const onError = (error: unknown) => {
+		(error as { response: { status: number } }).response.status === 404 &&
+			router.replace('/404');
+	};
+
 	const {
 		data: mediaInfo,
 		isLoading: isLoadingMediaInfo,
 		isError,
-	} = useGetMediaInfo(router.query.ie as string);
+	} = useGetMediaInfo(router.query.ie as string, onError);
 
 	// playable url
 	const {


### PR DESCRIPTION
- redirect to 404 als `ie` niet bestaat