### PR TITLE
fix(logged-in-home): remove double slash in tos redirect

### DIFF
--- a/src/modules/home/components/LoggedInHome/LoggedInHome.tsx
+++ b/src/modules/home/components/LoggedInHome/LoggedInHome.tsx
@@ -108,7 +108,7 @@ const LoggedInHome: FC = () => {
 		if (isRequestAccessBladeOpen) {
 			if (user && !user.acceptedTosAt) {
 				router.push(
-					`/${ROUTES.termsOfService}?${REDIRECT_TO_QUERY_KEY}=${encodeURIComponent(
+					`${ROUTES.termsOfService}?${REDIRECT_TO_QUERY_KEY}=${encodeURIComponent(
 						router.asPath
 					)}`
 				);


### PR DESCRIPTION
Invalid href passed to next/router:
//gebruiksvoorwaarden?redirectTo=%2F%3Fbezoekersruimte%3Dvrt,
repeated forward-slashes (//) or backslashes \ are not valid in the href