### PR TITLE
fix(arc-627): mobile filter icon position on safari

### DIFF
--- a/src/modules/reading-room/components/FilterMenu/FilterMenuMobile/FilterMenuMobile.tsx
+++ b/src/modules/reading-room/components/FilterMenu/FilterMenuMobile/FilterMenuMobile.tsx
@@ -71,7 +71,7 @@ const FilterMenuMobile: FC<FilterMenuMobileProps> = ({
 						<Button
 							key="filter-menu-mobile-nav-close"
 							className={styles['c-filter-menu-mobile__back']}
-							iconStart={<Icon name="arrow-left" />}
+							iconStart={<Icon className="u-text-left" name="arrow-left" />}
 							label={t(
 								'modules/reading-room/components/filter-menu/filter-menu-mobile/filter-menu-mobile___zoekresultaten'
 							)}


### PR DESCRIPTION
[ARC-627](https://meemoo.atlassian.net/browse/ARC-627)
- Mobile filter menu icon position on safari