### PR TITLE
fix(arc-708): Correctly render new lines in description and abstract

### DIFF
--- a/src/modules/media/const/index.tsx
+++ b/src/modules/media/const/index.tsx
@@ -4,8 +4,7 @@ import { ActionItem, MetadataItem, ObjectPlaceholderProps } from '@media/compone
 import { objectPlaceholderMock } from '@media/components/ObjectPlaceholder/__mocks__/object-placeholder';
 import { Media, MediaActions, ObjectDetailTabs } from '@media/types';
 import { mapArrayToMetadataData, mapObjectToMetadata } from '@media/utils';
-import { renderWithNewLines } from '@media/utils/render-with-new-lines';
-import { Icon } from '@shared/components';
+import { Icon, TextWithNewLines } from '@shared/components';
 import { i18n } from '@shared/helpers/i18n';
 import { MediaTypes } from '@shared/types';
 
@@ -173,7 +172,7 @@ export const METADATA_FIELDS = (mediaInfo: Media): MetadataItem[] =>
 		...mapObjectToMetadata(mediaInfo.publisher),
 		{
 			title: i18n.t('modules/media/const/index___uitgebreide-beschrijving'),
-			data: renderWithNewLines(mediaInfo?.abstract, 'u-color-neutral'),
+			data: <TextWithNewLines text={mediaInfo?.abstract} className="u-color-neutral" />,
 		},
 		{
 			title: i18n.t('modules/media/const/index___transcriptie'),

--- a/src/modules/media/const/index.tsx
+++ b/src/modules/media/const/index.tsx
@@ -1,12 +1,11 @@
 import { TabProps } from '@meemoo/react-components';
-import DOMPurify from 'dompurify';
 
 import { ActionItem, MetadataItem, ObjectPlaceholderProps } from '@media/components';
 import { objectPlaceholderMock } from '@media/components/ObjectPlaceholder/__mocks__/object-placeholder';
 import { Media, MediaActions, ObjectDetailTabs } from '@media/types';
 import { mapArrayToMetadataData, mapObjectToMetadata } from '@media/utils';
+import { renderWithNewLines } from '@media/utils/render-with-new-lines';
 import { Icon } from '@shared/components';
-import { RICH_TEXT_SANITIZATION } from '@shared/const';
 import { i18n } from '@shared/helpers/i18n';
 import { MediaTypes } from '@shared/types';
 
@@ -174,19 +173,7 @@ export const METADATA_FIELDS = (mediaInfo: Media): MetadataItem[] =>
 		...mapObjectToMetadata(mediaInfo.publisher),
 		{
 			title: i18n.t('modules/media/const/index___uitgebreide-beschrijving'),
-			data: mediaInfo.abstract ? (
-				<div
-					className="u-color-neutral"
-					dangerouslySetInnerHTML={{
-						__html: String(
-							DOMPurify.sanitize(
-								mediaInfo.abstract.replaceAll('\n', '<br/><br/>'),
-								RICH_TEXT_SANITIZATION
-							)
-						),
-					}}
-				/>
-			) : null,
+			data: renderWithNewLines(mediaInfo?.abstract, 'u-color-neutral'),
 		},
 		{
 			title: i18n.t('modules/media/const/index___transcriptie'),

--- a/src/modules/media/utils/render-with-new-lines.tsx
+++ b/src/modules/media/utils/render-with-new-lines.tsx
@@ -1,0 +1,24 @@
+import DOMPurify from 'dompurify';
+import { ReactNode } from 'react';
+
+import { RICH_TEXT_SANITIZATION } from '@shared/const';
+
+export function renderWithNewLines(text: string | null | undefined, className?: string): ReactNode {
+	if (!text) {
+		return null;
+	}
+	return (
+		<div
+			className={className}
+			dangerouslySetInnerHTML={{
+				__html: String(
+					DOMPurify.sanitize(
+						// Replace new lines and literal new lines (description and abstract are encoded differently)
+						text.replaceAll('\\n', '<br/><br/>').replaceAll('\n', '<br/><br/>'),
+						RICH_TEXT_SANITIZATION
+					)
+				),
+			}}
+		/>
+	);
+}

--- a/src/modules/shared/components/TextWithNewLines/TextWithNewLines.tsx
+++ b/src/modules/shared/components/TextWithNewLines/TextWithNewLines.tsx
@@ -1,9 +1,14 @@
 import DOMPurify from 'dompurify';
-import { ReactNode } from 'react';
+import { FC } from 'react';
 
 import { RICH_TEXT_SANITIZATION } from '@shared/const';
 
-export function renderWithNewLines(text: string | null | undefined, className?: string): ReactNode {
+interface TextWithNewLinesProps {
+	text: string | null | undefined;
+	className?: string;
+}
+
+const TextWithNewLines: FC<TextWithNewLinesProps> = ({ text, className }) => {
 	if (!text) {
 		return null;
 	}
@@ -21,4 +26,6 @@ export function renderWithNewLines(text: string | null | undefined, className?: 
 			}}
 		/>
 	);
-}
+};
+
+export default TextWithNewLines;

--- a/src/modules/shared/components/TextWithNewLines/index.ts
+++ b/src/modules/shared/components/TextWithNewLines/index.ts
@@ -1,0 +1,1 @@
+export { default as TextWithNewLines } from './TextWithNewLines';

--- a/src/modules/shared/components/index.ts
+++ b/src/modules/shared/components/index.ts
@@ -28,6 +28,7 @@ export * from './SidebarLayoutTitle';
 export * from './Table';
 export * from './Tabs';
 export * from './TagsInput';
+export * from './TextWithNewLines';
 export * from './Timepicker';
 export * from './Toast';
 export * from './Toggle';

--- a/src/pages/[slug]/[ie]/index.tsx
+++ b/src/pages/[slug]/[ie]/index.tsx
@@ -41,7 +41,6 @@ import {
 	ObjectDetailTabs,
 } from '@media/types';
 import { mapKeywordsToTagList } from '@media/utils';
-import { renderWithNewLines } from '@media/utils/render-with-new-lines';
 import { AddToCollectionBlade, ReadingRoomNavigation } from '@reading-room/components';
 import {
 	ErrorNotFound,
@@ -50,6 +49,7 @@ import {
 	Loading,
 	ScrollableTabs,
 	TabLabel,
+	TextWithNewLines,
 } from '@shared/components';
 import Callout from '@shared/components/Callout/Callout';
 import { useHasAllPermission } from '@shared/hooks/has-permission';
@@ -467,7 +467,10 @@ const ObjectDetailPage: NextPage = () => {
 						{mediaInfo?.name}
 					</h3>
 					<p className="u-pb-24 u-line-height-1-4 u-font-size-14">
-						{renderWithNewLines(mediaInfo?.description, 'u-color-neutral')}
+						<TextWithNewLines
+							text={mediaInfo?.description}
+							className="u-color-neutral"
+						/>
 					</p>
 					<div className="u-pb-24 p-object-detail__actions">
 						{canDownloadMetadata && (

--- a/src/pages/[slug]/[ie]/index.tsx
+++ b/src/pages/[slug]/[ie]/index.tsx
@@ -41,6 +41,7 @@ import {
 	ObjectDetailTabs,
 } from '@media/types';
 import { mapKeywordsToTagList } from '@media/utils';
+import { renderWithNewLines } from '@media/utils/render-with-new-lines';
 import { AddToCollectionBlade, ReadingRoomNavigation } from '@reading-room/components';
 import {
 	ErrorNotFound,
@@ -466,7 +467,7 @@ const ObjectDetailPage: NextPage = () => {
 						{mediaInfo?.name}
 					</h3>
 					<p className="u-pb-24 u-line-height-1-4 u-font-size-14">
-						{mediaInfo?.description}
+						{renderWithNewLines(mediaInfo?.description, 'u-color-neutral')}
 					</p>
 					<div className="u-pb-24 p-object-detail__actions">
 						{canDownloadMetadata && (


### PR DESCRIPTION
You can test this by manually updating an object description in the database:
http://localhost:3200/vrt/49b1bf8894004fd49aeaba36cfc5a958d5c32a4566244999a862e80b498a2c7c7bee152896204294938534fc7f3c6793
![image](https://user-images.githubusercontent.com/1710840/165707598-645c1f96-817c-4114-aabc-e2e397b098de.png)

![image](https://user-images.githubusercontent.com/1710840/165707389-4b6968c9-b64e-41d8-af92-4d6e887547ab.png)
![image](https://user-images.githubusercontent.com/1710840/165707395-bd4ab3a0-28e4-48b0-8ec5-241880c4141e.png)
