### PR TITLE
fix(arc-213): Do not send %% if query in folder is empty

### DIFF
--- a/src/modules/account/services/collections/collections.service.ts
+++ b/src/modules/account/services/collections/collections.service.ts
@@ -27,7 +27,7 @@ class CollectionsService extends ApiService {
 				stringifyUrl({
 					url: `${COLLECTIONS_SERVICE_BASE_URL}/${id}`,
 					query: {
-						query: `%${searchInput}%`,
+						...(searchInput ? { query: `%${searchInput}%` } : {}),
 						page,
 						size,
 					},


### PR DESCRIPTION
This makes the query a bit more efficient

Related PR: https://github.com/viaacode/hetarchief-proxy/pull/173