### PR TITLE
feat(arc-670): licenses

### DIFF
--- a/src/pages/[slug]/[ie]/index.tsx
+++ b/src/pages/[slug]/[ie]/index.tsx
@@ -226,12 +226,12 @@ const ObjectDetailPage: NextPage = () => {
 
 		// Filter out peak files if type === video
 		if (mediaInfo?.dctermsFormat === ReadingRoomMediaType.Video) {
-			mediaInfo.representations = mediaInfo?.representations.filter(
+			mediaInfo.representations = mediaInfo?.representations?.filter(
 				(object) => object.dctermsFormat !== 'peak'
 			);
 		}
 
-		setCurrentRepresentation(mediaInfo?.representations[0]);
+		setCurrentRepresentation(mediaInfo?.representations?.[0]);
 
 		// Set default view
 		if (isMobile) {


### PR DESCRIPTION
Representations are missing if the object doesn't have a valid license to show essence.

See also: https://github.com/viaacode/hetarchief-proxy/pull/179