### PR TITLE
fix(arc-803): hide empty descriptions

### DIFF
--- a/src/modules/media/const/index.tsx
+++ b/src/modules/media/const/index.tsx
@@ -173,7 +173,9 @@ export const METADATA_FIELDS = (mediaInfo: Media): MetadataItem[] =>
 		...mapObjectToMetadata(mediaInfo.publisher),
 		{
 			title: i18n.t('modules/media/const/index___uitgebreide-beschrijving'),
-			data: <TextWithNewLines text={mediaInfo?.abstract} className="u-color-neutral" />,
+			data: mediaInfo?.abstract ? (
+				<TextWithNewLines text={mediaInfo?.abstract} className="u-color-neutral" />
+			) : null,
 		},
 		{
 			title: i18n.t('modules/media/const/index___transcriptie'),


### PR DESCRIPTION
[ARC-803](https://meemoo.atlassian.net/browse/ARC-803)
- `Uitgebreide beschrijving` enkel zichtbaar als de waarde niet leeg is

⚠️ 
- Dit is niet nodig voor de gewone description omdat `TextWithNewLines` `null` terug geeft.
- Wel nodig in `METADATA_FIELDS` omdat de return value nog steeds een ReactNode is.