### PR TITLE
fix(arc-762): fix initial notifications check

### DIFF
--- a/src/modules/shared/services/notifications-service/notifications.service.test.ts
+++ b/src/modules/shared/services/notifications-service/notifications.service.test.ts
@@ -1,0 +1,337 @@
+import { NotificationsService } from '@shared/services/notifications-service/notifications.service';
+import { Notification } from '@shared/services/notifications-service/notifications.types';
+import { toastService } from '@shared/services/toast-service';
+import { ApiResponseWrapper } from '@shared/types';
+
+const oldDate = '2022-05-03T16:30:39.70604+00:00';
+const newDate = '2022-05-04T16:30:48.824352+00:00';
+const newestDate = '2022-05-05T16:30:48.824352+00:00';
+
+const mockReadNotification = {
+	id: '66f12986-a17a-44be-9b1d-1966fa28ee65',
+	description:
+		'Je aanvraag voor leeszaal AMVB is goedgekeurd. Je zal toegang hebben van 03/05/2022 17:45 tot 03/05/2022 19:30',
+	title: 'Je aanvraag voor leeszaal AMVB is goedgekeurd',
+	status: 'READ',
+	visitId: '8ad7d557-5dd0-42a6-99e8-4da9c65e35fe',
+	createdAt: oldDate,
+	updatedAt: oldDate,
+	type: 'VISIT_REQUEST_APPROVED',
+	visitorSpaceSlug: 'amvb',
+};
+
+const mockUnreadNotification = {
+	id: '5467ed49-23d7-40a2-b5cc-4408a98f268b',
+	description: 'Je toegang vervalt terug op 03/05/2022 19:30',
+	title: 'Je hebt nu toegang tot de leeszaal AMVB',
+	status: 'UNREAD',
+	visitId: '8ad7d557-5dd0-42a6-99e8-4da9c65e35fe',
+	createdAt: oldDate,
+	updatedAt: oldDate,
+	type: 'ACCESS_PERIOD_READING_ROOM_STARTED',
+	visitorSpaceSlug: 'amvb',
+};
+
+const mockNewUnreadNotification = {
+	id: '5467ed49-23d7-40a2-b5cc-4408a98f268b',
+	description: 'Je toegang vervalt terug op 03/05/2022 19:30',
+	title: 'Je hebt nu toegang tot de leeszaal AMVB',
+	status: 'UNREAD',
+	visitId: '8ad7d557-5dd0-42a6-99e8-4da9c65e35fe',
+	createdAt: newDate,
+	updatedAt: newDate,
+	type: 'ACCESS_PERIOD_READING_ROOM_STARTED',
+	visitorSpaceSlug: 'amvb',
+};
+
+describe('NotificationService', () => {
+	afterEach(() => {
+		NotificationsService.resetService();
+	});
+
+	describe('checkNotifications()', () => {
+		it('Should not show any toasts when the first notifications are fetched and the response is empty', async () => {
+			const mockSetHasUnreadNotifications = jest.fn();
+			await NotificationsService.initPolling(
+				null as any,
+				null as any,
+				mockSetHasUnreadNotifications
+			);
+			NotificationsService.getNotifications = jest.fn().mockResolvedValueOnce({
+				items: [],
+				total: 0,
+				pages: 1,
+				page: 1,
+				size: 20,
+			} as ApiResponseWrapper<Notification>);
+			const mockedNotifyFunc = jest.fn();
+			toastService.notify = mockedNotifyFunc;
+
+			await NotificationsService.checkNotifications();
+
+			expect(mockedNotifyFunc).toBeCalledTimes(0);
+
+			expect(mockSetHasUnreadNotifications).toBeCalledTimes(0);
+		});
+
+		it('Should not show any toasts when the first notifications are fetched and the response contains only READ notifications', async () => {
+			const mockSetHasUnreadNotifications = jest.fn();
+			await NotificationsService.initPolling(
+				null as any,
+				null as any,
+				mockSetHasUnreadNotifications
+			);
+			NotificationsService.getNotifications = jest.fn().mockResolvedValueOnce({
+				items: [mockReadNotification, mockReadNotification],
+				total: 2,
+				pages: 1,
+				page: 1,
+				size: 20,
+			} as ApiResponseWrapper<Notification>);
+			const mockedNotifyFunc = jest.fn();
+			toastService.notify = mockedNotifyFunc;
+
+			await NotificationsService.checkNotifications();
+
+			expect(mockedNotifyFunc).toBeCalledTimes(0);
+
+			expect(mockSetHasUnreadNotifications).toBeCalledTimes(0);
+		});
+
+		it('Should not show any toasts when the first notifications are fetched and the response contains only UNREAD notifications', async () => {
+			const mockSetHasUnreadNotifications = jest.fn();
+			await NotificationsService.initPolling(
+				null as any,
+				null as any,
+				mockSetHasUnreadNotifications
+			);
+			NotificationsService.getNotifications = jest.fn().mockResolvedValueOnce({
+				items: [mockUnreadNotification, mockUnreadNotification],
+				total: 2,
+				pages: 1,
+				page: 1,
+				size: 20,
+			} as ApiResponseWrapper<Notification>);
+			const mockedNotifyFunc = jest.fn();
+			toastService.notify = mockedNotifyFunc;
+
+			await NotificationsService.checkNotifications();
+
+			expect(mockedNotifyFunc).toBeCalledTimes(0);
+
+			expect(mockSetHasUnreadNotifications).toBeCalledTimes(1);
+		});
+
+		it('Should not show any toasts when the first notifications are fetched and the response contains both UNREAD and READ notifications', async () => {
+			const mockSetHasUnreadNotifications = jest.fn();
+			await NotificationsService.initPolling(
+				null as any,
+				null as any,
+				mockSetHasUnreadNotifications
+			);
+			NotificationsService.getNotifications = jest.fn().mockResolvedValueOnce({
+				items: [mockUnreadNotification, mockReadNotification],
+				total: 2,
+				pages: 1,
+				page: 1,
+				size: 20,
+			} as ApiResponseWrapper<Notification>);
+			const mockedNotifyFunc = jest.fn();
+			toastService.notify = mockedNotifyFunc;
+
+			await NotificationsService.checkNotifications();
+
+			expect(mockedNotifyFunc).toBeCalledTimes(0);
+
+			expect(mockSetHasUnreadNotifications).toBeCalledTimes(1);
+		});
+
+		it('Should show a single toasts when a new UNREAD notification is fetched', async () => {
+			const mockSetHasUnreadNotifications = jest.fn();
+			await NotificationsService.initPolling(
+				null as any,
+				null as any,
+				mockSetHasUnreadNotifications
+			);
+			NotificationsService.getNotifications = jest
+				.fn()
+				.mockResolvedValueOnce({
+					items: [mockUnreadNotification, mockReadNotification],
+					total: 2,
+					pages: 1,
+					page: 1,
+					size: 20,
+				} as ApiResponseWrapper<Notification>)
+				.mockResolvedValueOnce({
+					items: [
+						mockNewUnreadNotification,
+						mockUnreadNotification,
+						mockReadNotification,
+					],
+					total: 3,
+					pages: 1,
+					page: 1,
+					size: 20,
+				} as ApiResponseWrapper<Notification>);
+			const mockedNotifyFunc = jest.fn();
+			toastService.notify = mockedNotifyFunc;
+
+			// Initial fetch
+			await NotificationsService.checkNotifications();
+
+			expect(mockedNotifyFunc).toBeCalledTimes(0);
+
+			// Next fetch
+			await NotificationsService.checkNotifications();
+
+			expect(mockedNotifyFunc).toBeCalledTimes(1);
+			expect(mockedNotifyFunc).toBeCalledWith(
+				expect.objectContaining({
+					buttonLabel: 'Bekijk ***',
+					description: 'Je toegang vervalt terug op 03/05/2022 19:30',
+					title: 'Je hebt nu toegang tot de leeszaal AMVB',
+				})
+			);
+
+			expect(mockSetHasUnreadNotifications).toBeCalledTimes(2);
+		});
+
+		it('Should show a single toasts when multiple new UNREAD notifications are fetched', async () => {
+			const mockSetHasUnreadNotifications = jest.fn();
+			await NotificationsService.initPolling(
+				null as any,
+				null as any,
+				mockSetHasUnreadNotifications
+			);
+			NotificationsService.getNotifications = jest
+				.fn()
+				.mockResolvedValueOnce({
+					items: [mockUnreadNotification, mockReadNotification],
+					total: 2,
+					pages: 1,
+					page: 1,
+					size: 20,
+				} as ApiResponseWrapper<Notification>)
+				.mockResolvedValueOnce({
+					items: [
+						mockNewUnreadNotification,
+						mockNewUnreadNotification,
+						mockUnreadNotification,
+						mockReadNotification,
+					],
+					total: 3,
+					pages: 1,
+					page: 1,
+					size: 20,
+				} as ApiResponseWrapper<Notification>);
+			const mockedNotifyFunc = jest.fn();
+			toastService.notify = mockedNotifyFunc;
+
+			// Initial fetch
+			await NotificationsService.checkNotifications();
+
+			expect(mockedNotifyFunc).toBeCalledTimes(0);
+
+			// Next fetch
+			await NotificationsService.checkNotifications();
+
+			expect(mockedNotifyFunc).toBeCalledTimes(1);
+			expect(mockedNotifyFunc).toBeCalledWith(
+				expect.objectContaining({
+					buttonLabel: 'Bekijk ***',
+					description:
+						'Er zijn aantal nieuwe notificaties bekijk ze in het notificatie overzicht ***',
+					title: 'Er zijn amount nieuwe notificaties ***',
+				})
+			);
+
+			expect(mockSetHasUnreadNotifications).toBeCalledTimes(2);
+		});
+
+		it('Should not show a new toast when the same notifications are fetched', async () => {
+			const mockSetHasUnreadNotifications = jest.fn();
+			await NotificationsService.initPolling(
+				null as any,
+				null as any,
+				mockSetHasUnreadNotifications
+			);
+			NotificationsService.getNotifications = jest
+				.fn()
+				.mockResolvedValueOnce({
+					items: [mockUnreadNotification, mockReadNotification],
+					total: 2,
+					pages: 1,
+					page: 1,
+					size: 20,
+				} as ApiResponseWrapper<Notification>)
+				.mockResolvedValueOnce({
+					items: [mockUnreadNotification, mockReadNotification],
+					total: 2,
+					pages: 1,
+					page: 1,
+					size: 20,
+				} as ApiResponseWrapper<Notification>);
+			const mockedNotifyFunc = jest.fn();
+			toastService.notify = mockedNotifyFunc;
+
+			// Initial fetch
+			await NotificationsService.checkNotifications();
+
+			expect(mockedNotifyFunc).toBeCalledTimes(0);
+
+			// Next fetch
+			await NotificationsService.checkNotifications();
+
+			expect(mockedNotifyFunc).toBeCalledTimes(0);
+
+			expect(mockSetHasUnreadNotifications).toBeCalledTimes(2);
+		});
+
+		it('Should not show a new toast when a new READ notification is fetched', async () => {
+			const mockSetHasUnreadNotifications = jest.fn();
+			await NotificationsService.initPolling(
+				null as any,
+				null as any,
+				mockSetHasUnreadNotifications
+			);
+			NotificationsService.getNotifications = jest
+				.fn()
+				.mockResolvedValueOnce({
+					items: [mockUnreadNotification, mockReadNotification],
+					total: 2,
+					pages: 1,
+					page: 1,
+					size: 20,
+				} as ApiResponseWrapper<Notification>)
+				.mockResolvedValueOnce({
+					items: [
+						mockUnreadNotification,
+						{
+							...mockReadNotification,
+							createdAt: newestDate,
+							updatedAt: newestDate,
+						},
+						mockReadNotification,
+					],
+					total: 2,
+					pages: 1,
+					page: 1,
+					size: 20,
+				} as ApiResponseWrapper<Notification>);
+			const mockedNotifyFunc = jest.fn();
+			toastService.notify = mockedNotifyFunc;
+
+			// Initial fetch
+			await NotificationsService.checkNotifications();
+
+			expect(mockedNotifyFunc).toBeCalledTimes(0);
+
+			// Next fetch
+			await NotificationsService.checkNotifications();
+
+			expect(mockedNotifyFunc).toBeCalledTimes(0);
+
+			expect(mockSetHasUnreadNotifications).toBeCalledTimes(2);
+		});
+	});
+});

--- a/src/modules/shared/services/notifications-service/notifications.service.ts
+++ b/src/modules/shared/services/notifications-service/notifications.service.ts
@@ -63,7 +63,7 @@ export abstract class NotificationsService {
 		const firstUnread = asDate(unreadNotifications?.[0]?.createdAt);
 
 		if (
-			!!mostRecent && // Do not show notifications if this is the first time we check since loading the site
+			!!NotificationsService.lastFetchedUnreadNotifications && // Do not show notifications if this is the first time we check since loading the site
 			firstUnread && // There is at least one unread notification
 			lastCheckNotificationTime < firstUnread.getTime() // The most recent unread notification was added since the last time we checked
 		) {

--- a/src/modules/shared/services/notifications-service/notifications.service.ts
+++ b/src/modules/shared/services/notifications-service/notifications.service.ts
@@ -14,7 +14,7 @@ import { MarkAllAsReadResult, Notification, NotificationStatus } from './notific
 
 export abstract class NotificationsService {
 	private static pollingTimer: number | null = null;
-	private static lastFetchedUnreadNotifications: Notification[] | null = null;
+	private static lastNotifications: Notification[] | null = null;
 	private static router: NextRouter | null = null;
 	private static showNotificationsCenter: ((show: boolean) => void) | null = null;
 	private static setHasUnreadNotifications: ((hasUnreadNotifications: boolean) => void) | null =
@@ -30,7 +30,7 @@ export abstract class NotificationsService {
 		this.router = router;
 		this.showNotificationsCenter = showNotificationsCenter;
 		this.setHasUnreadNotifications = setHasUnreadNotifications;
-		if (!this.pollingTimer) {
+		if (!this.pollingTimer && process.env.NODE_ENV !== 'test') {
 			NotificationsService.pollingTimer = window.setInterval(this.checkNotifications, 15000);
 			await this.checkNotifications();
 		}
@@ -42,6 +42,14 @@ export abstract class NotificationsService {
 		}
 	}
 
+	public static resetService(): void {
+		this.pollingTimer = null;
+		this.lastNotifications = null;
+		this.router = null;
+		this.showNotificationsCenter = null;
+		this.setHasUnreadNotifications = null;
+	}
+
 	public static getPath(notification: Notification): string | null {
 		return (
 			NOTIFICATION_TYPE_TO_PATH[notification.type]
@@ -51,9 +59,7 @@ export abstract class NotificationsService {
 	}
 
 	public static async checkNotifications(): Promise<void> {
-		const mostRecent = asDate(
-			NotificationsService.lastFetchedUnreadNotifications?.[0].createdAt
-		);
+		const mostRecent = asDate(NotificationsService.lastNotifications?.[0]?.createdAt);
 		const lastCheckNotificationTime = mostRecent ? mostRecent.getTime() : 0;
 		const notificationResponse = await NotificationsService.getNotifications(1, 20);
 		const notifications = notificationResponse.items;
@@ -63,9 +69,9 @@ export abstract class NotificationsService {
 		const firstUnread = asDate(unreadNotifications?.[0]?.createdAt);
 
 		if (
-			!!NotificationsService.lastFetchedUnreadNotifications && // Do not show notifications if this is the first time we check since loading the site
+			!!NotificationsService.lastNotifications && // Do not show notifications if this is the first time we check since loading the site
 			firstUnread && // There is at least one unread notification
-			lastCheckNotificationTime < firstUnread.getTime() // The most recent unread notification was added since the last time we checked
+			(!mostRecent || lastCheckNotificationTime < firstUnread.getTime()) // The most recent unread notification was added since the last time we checked
 		) {
 			// A more recent notification exists, we should notify the user of the new notifications
 			const newNotifications = unreadNotifications.filter(
@@ -114,8 +120,8 @@ export abstract class NotificationsService {
 				});
 			}
 		}
+		NotificationsService.lastNotifications = notifications;
 		if (unreadNotifications.length > 0) {
-			NotificationsService.lastFetchedUnreadNotifications = unreadNotifications;
 			NotificationsService.setHasUnreadNotifications?.(true);
 			await NotificationsService.queryClient.invalidateQueries(QUERY_KEYS.getNotifications);
 		}
@@ -136,8 +142,8 @@ export abstract class NotificationsService {
 			.patch(`notifications/${notificationId}/mark-as-read`)
 			.json();
 		if (
-			(NotificationsService.lastFetchedUnreadNotifications?.filter(
-				(notif) => notif.id !== notificationId
+			(NotificationsService.lastNotifications?.filter(
+				(notif) => notif.id !== notificationId && notif.status === NotificationStatus.UNREAD
 			)?.length || 0) === 0
 		) {
 			NotificationsService.setHasUnreadNotifications?.(false);


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-762

* Check if initial notifications have been loaded => don't show notification for first fetch
* if first fetch is empty array => still counts as first fetch
* Add tests

![image](https://user-images.githubusercontent.com/1710840/166504121-30cfd3d8-e634-4d36-9a69-870e4734b914.png)

![image](https://user-images.githubusercontent.com/1710840/166504116-27969241-ae9e-489c-83ba-79b1704c1d09.png)
