### PR TITLE
fix(media-card): set image placeholder height to 16:9 for nicer loading

### DIFF
--- a/src/modules/shared/components/MediaCard/MediaCard.module.scss
+++ b/src/modules/shared/components/MediaCard/MediaCard.module.scss
@@ -29,7 +29,7 @@ $c-media-card-no-video-intended-spacing: 0.9rem;
 
 				> img {
 					position: static !important;
-					height: auto !important;
+					height: calc(238px / 16 * 9) !important;
 				}
 			}
 		}


### PR DESCRIPTION
Currently when loading the media on the search page, before the images load, a square white space is reserved.
After loading the images that space collapses to a 16 by 9 size.

![image](https://user-images.githubusercontent.com/1710840/166508758-75e93e35-1d2f-425b-83ef-46eb8104cf20.png)

![image](https://user-images.githubusercontent.com/1710840/166508769-80db404d-1be9-4238-8d85-0e2dc06de4c0.png)

By setting the image size to be 16:9 by default, we get a nicer loading behavior.

![image](https://user-images.githubusercontent.com/1710840/166508787-91109d1c-7ad8-4cb2-b631-142860615b2b.png)


For the images that are not 16:9, the nextimage is set to be fill, so it will just be cropped to 16:9.

