### PR TITLE
fix(avo-708): fix double new lines in object description and abstract

### DIFF
--- a/src/modules/shared/components/TextWithNewLines/TextWithNewLines.tsx
+++ b/src/modules/shared/components/TextWithNewLines/TextWithNewLines.tsx
@@ -19,7 +19,7 @@ const TextWithNewLines: FC<TextWithNewLinesProps> = ({ text, className }) => {
 				__html: String(
 					DOMPurify.sanitize(
 						// Replace new lines and literal new lines (description and abstract are encoded differently)
-						text.replaceAll('\\n', '<br/><br/>').replaceAll('\n', '<br/><br/>'),
+						text.replaceAll('\\n', '<br/>').replaceAll('\n', '<br/>'),
 						RICH_TEXT_SANITIZATION
 					)
 				),


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-708

before:
![image](https://user-images.githubusercontent.com/1710840/166639518-eb175db0-bb39-47ee-b9c4-eed439e05551.png)

after:
![image](https://user-images.githubusercontent.com/1710840/166639527-523e395e-38eb-4688-8c29-5e4adfe995d3.png)

