### PR TITLE
fix(arc-787): logout when api returns 401 unauthorized

### DIFF
--- a/src/modules/shared/services/api-service/api.service.ts
+++ b/src/modules/shared/services/api-service/api.service.ts
@@ -2,6 +2,8 @@ import ky from 'ky-universal';
 import { KyInstance } from 'ky/distribution/types/ky';
 import getConfig from 'next/config';
 
+import { AuthService } from '@auth/services/auth-service';
+
 const { publicRuntimeConfig } = getConfig();
 
 export abstract class ApiService {
@@ -15,6 +17,16 @@ export abstract class ApiService {
 					'content-type': 'application/json',
 				},
 				credentials: 'include', // TODO change to same-origin once working on server
+				hooks: {
+					afterResponse: [
+						(_request, _options, response) => {
+							if (response.status === 401) {
+								// user is unauthorized and should login again
+								AuthService.logout();
+							}
+						},
+					],
+				},
 			});
 		}
 		return this.api as KyInstance;


### PR DESCRIPTION
logout when api returns 401 unauthorized.

Related proxy PR: https://github.com/viaacode/hetarchief-proxy/pull/181