### PR TITLE
fix(arc-161): fix cookie policy translations

### DIFF
--- a/src/pages/cookiebeleid/index.tsx
+++ b/src/pages/cookiebeleid/index.tsx
@@ -1,6 +1,8 @@
-import { NextPage } from 'next';
+import { GetStaticProps, NextPage } from 'next';
 import Script from 'next/script';
 import React from 'react';
+
+import { withI18n } from '@i18n/wrappers';
 
 import styles from './cookie-policy.module.scss';
 
@@ -15,5 +17,7 @@ const CookiePolicy: NextPage = () => {
 		</div>
 	);
 };
+
+export const getStaticProps: GetStaticProps = withI18n();
 
 export default CookiePolicy;


### PR DESCRIPTION
I'm assuming cookiebot does not want to load on localhost
We'll see if it starts working on QAS

Translations do not show any *** anymore

![image](https://user-images.githubusercontent.com/1710840/167104479-a3b35594-4c60-4c38-be95-f741d8f60ac9.png)
