### PR TITLE
fix(arc-611): fix router functions in admin core config object

### DIFF
--- a/src/modules/admin/wrappers/with-admin-core-config.tsx
+++ b/src/modules/admin/wrappers/with-admin-core-config.tsx
@@ -10,6 +10,7 @@ import { CommonUser } from '@meemoo/react-admin/dist/cjs/modules/user/user.types
 import { i18n } from 'next-i18next';
 import getConfig from 'next/config';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 // import { useRouter } from 'next/router';
 import { ComponentType, FunctionComponent, useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -38,29 +39,14 @@ export const withAdminCoreConfig = (WrappedComponent: ComponentType): ComponentT
 		const [adminCoreConfig, setAdminCoreConfig] = useState<ConfigValue | null>(null);
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		const user = useSelector(selectUser);
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		const router = useRouter();
 
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		const initConfigValue = useCallback(() => {
 			if (!i18n) {
 				return;
 			}
-
-			const routerConfig: ConfigValue['services']['router'] = {
-				Link: InternalLink as FunctionComponent<LinkInfo>,
-				useHistory: () => ({
-					push: () => {
-						// empty
-					},
-					replace: () => {
-						// empty
-					},
-				}), //useRouter,
-				useParams: () => {
-					// const router = useRouter();
-					// return router.query as Record<string, string>;
-					return {};
-				},
-			};
 
 			const commonUser: CommonUser = {
 				uid: user?.id,
@@ -132,7 +118,16 @@ export const withAdminCoreConfig = (WrappedComponent: ComponentType): ComponentT
 						fetchCities: () => Promise.resolve([]),
 						fetchEducationOrganisations: () => Promise.resolve([]),
 					},
-					router: routerConfig as any,
+					router: {
+						Link: InternalLink as FunctionComponent<LinkInfo>,
+						useHistory: () => ({
+							push: router.push,
+							replace: router.replace,
+						}), //useRouter,
+						useParams: () => {
+							return router.query as Record<string, string>;
+						},
+					},
 					queryCache: {
 						// eslint-disable-next-line @typescript-eslint/no-unused-vars
 						clear: async (_key: string) => Promise.resolve(),

--- a/src/modules/admin/wrappers/with-admin-core-config.tsx
+++ b/src/modules/admin/wrappers/with-admin-core-config.tsx
@@ -21,6 +21,7 @@ import { navigationService } from '@navigation/services/navigation-service';
 import { sortingIcons } from '@shared/components';
 import Loading from '@shared/components/Loading/Loading';
 import { AssetsService } from '@shared/services/assets-service/assets.service';
+import { toastService } from '@shared/services/toast-service';
 
 const InternalLink = (linkInfo: LinkInfo) => {
 	const { to, ...rest } = linkInfo;
@@ -108,8 +109,10 @@ export const withAdminCoreConfig = (WrappedComponent: ComponentType): ComponentT
 				services: {
 					toastService: {
 						showToast: (toastInfo: ToastInfo) => {
-							// Client decides how the toast messages are shown
-							console.log('show toast: ', toastInfo);
+							toastService.notify({
+								title: toastInfo.title,
+								description: toastInfo.description,
+							});
 						},
 					},
 					i18n,


### PR DESCRIPTION
after editing a content page, the app should navigate to the detail view

* Integrate the config service.router functions 
* Integrate the config service.toatService functions

![image](https://user-images.githubusercontent.com/1710840/169776479-9ec70e16-11ff-4b55-97c6-344e316d0a3c.png)
