### PR TITLE
fix(arc-162): improve hiding of zendesk widget when not yet loaded

### DIFF
--- a/src/modules/shared/components/ZendeskWrapper/ZendeskWrapper.tsx
+++ b/src/modules/shared/components/ZendeskWrapper/ZendeskWrapper.tsx
@@ -18,10 +18,10 @@ const ZendeskWrapper: FunctionComponent = () => {
 	const zendeskMarginRight = 31;
 
 	useEffect(() => {
-		const zendeskWidget: HTMLIFrameElement | null = document.querySelector('iframe#launcher');
-		if (zendeskWidget) {
-			zendeskWidget.style.display = showZendesk ? 'block' : 'none';
-			zendeskWidget.style.width = 'auto';
+		if (showZendesk) {
+			document.body.classList.remove('hide-zendesk-widget');
+		} else {
+			document.body.classList.add('hide-zendesk-widget');
 		}
 	}, [showZendesk]);
 

--- a/src/styles/layouts/_index.scss
+++ b/src/styles/layouts/_index.scss
@@ -1,3 +1,4 @@
 @use "app" as *;
 @use "container" as *;
 @use "content-block-preview" as *;
+@use "zendesk" as *;

--- a/src/styles/layouts/_zendesk.scss
+++ b/src/styles/layouts/_zendesk.scss
@@ -1,0 +1,3 @@
+body.hide-zendesk-widget #launcher {
+	display: none;
+}


### PR DESCRIPTION
Show/hide zendesk widet using a class on body
so we don't have to wait for the zendesk widget to initialise, before being able to hide it.