### PR TITLE
fix(arc-818): Safely get schema identifier of file when does not exist

### DIFF
--- a/src/pages/[slug]/[ie]/index.tsx
+++ b/src/pages/[slug]/[ie]/index.tsx
@@ -155,8 +155,8 @@ const ObjectDetailPage: NextPage = () => {
 			// Ignore peak file containing the audio wave form in json format
 			return false;
 		}
-		if (object.files[0].schemaIdentifier.endsWith('/audio_mp4')) {
-			// Ignore video files containing the speaker and audio
+		if (object?.files?.[0]?.schemaIdentifier?.endsWith('/audio_mp4')) {
+			// Ignore video files containing the ugly speaker image and the audio encoded in mp4 format
 			return false;
 		}
 		// Actual video files and mp3 files and images


### PR DESCRIPTION
Partially solves: https://meemoo.atlassian.net/browse/ARC-818

Fix error when getting schema identifier of first file, but first file does not exist
![image](https://user-images.githubusercontent.com/1710840/171398102-f648dd19-ce2f-416a-8776-5196c00a72af.png)

```
framework-79bce4a3a540b080.js:1 TypeError: Cannot read properties of undefined (reading 'schemaIdentifier')
    at [ie]-5bea180606a15db3.js:1:25295
    at Array.filter (<anonymous>)
    at [ie]-5bea180606a15db3.js:1:25231
    at oo (framework-79bce4a3a540b080.js:1:59417)
    at Wo (framework-79bce4a3a540b080.js:1:68984)
    at Ku (framework-79bce4a3a540b080.js:1:112708)
    at Li (framework-79bce4a3a540b080.js:1:98958)
    at Ni (framework-79bce4a3a540b080.js:1:98886)
    at Pi (framework-79bce4a3a540b080.js:1:98749)
    at bi (framework-79bce4a3a540b080.js:1:95715)
```