### PR TITLE
fix(arc-371): Enable scroll when filter menu becomes too large + margins

### DIFF
--- a/src/modules/visitor-space/components/FilterMenu/FilterMenuMobile/FilterMenuMobile.module.scss
+++ b/src/modules/visitor-space/components/FilterMenu/FilterMenuMobile/FilterMenuMobile.module.scss
@@ -9,6 +9,7 @@
 	z-index: get-z-layer("filter-menu-mobile");
 	background-color: $black;
 	color: $white;
+	overflow-y: auto;
 
 	:global(.c-tag-list) {
 		margin: $spacer-sm 0 $spacer-md;

--- a/src/styles/pages/_visitor-space.scss
+++ b/src/styles/pages/_visitor-space.scss
@@ -1,44 +1,44 @@
 @use "../abstracts" as *;
 
 .p-visitor-space {
-  display: flex;
-  flex-direction: column;
-  flex: 1 1 auto;
+	display: flex;
+	flex-direction: column;
+	flex: 1 1 auto;
 }
 
 .p-visitor-space__results {
-  display: flex;
-  flex-direction: column;
-  flex: 1 1 auto;
+	display: flex;
+	flex-direction: column;
+	flex: 1 1 auto;
 
-  &--placeholder {
-	.l-container {
-	  display: flex;
-	  flex: 1 1 auto;
+	&--placeholder {
+		.l-container {
+			display: flex;
+			flex: 1 1 auto;
 
-	  @include respond-to("md") {
-		flex-direction: column;
-	  }
+			@include respond-to("md") {
+				flex-direction: column;
+			}
+		}
+
+		.p-visitor-space__filter-menu {
+			flex-shrink: 0;
+
+			@include respond-at("md") {
+				width: calc(100% / 3 - 2.2rem);
+			}
+			@include respond-at("lg") {
+				width: calc(25% - 2.4rem);
+			}
+		}
 	}
-
-	.p-visitor-space__filter-menu {
-	  flex-shrink: 0;
-
-	  @include respond-at("md") {
-		width: calc(100% / 3 - 2.2rem);
-	  }
-	  @include respond-at("lg") {
-		width: calc(25% - 2.4rem);
-	  }
-	}
-  }
 }
 
 .p-visitor-space__placeholder {
-  margin: $spacer-md 0 auto;
+	margin: $spacer-lg * 2 0 $spacer-lg * 4;
 
-  @include respond-at("md") {
-	margin: auto 0;
-	margin-left: $spacer-md;
-  }
+	@include respond-at("md") {
+		margin: 64px 0 0;
+		margin-left: $spacer-md;
+	}
 }


### PR DESCRIPTION
* Add scroll for mobile filters when they get too large
* Increase the padding for the empty placeholder on mobile and desktop

![image](https://user-images.githubusercontent.com/1710840/171409707-cce31cf7-ec33-4724-9067-89d32ea69d67.png)

![image](https://user-images.githubusercontent.com/1710840/171409723-67f71240-75c0-41a6-b333-e81703a67f9e.png)


![image](https://user-images.githubusercontent.com/1710840/171409741-21ecb4bd-3271-4555-bb44-1a9343ab1d2e.png)

![image](https://user-images.githubusercontent.com/1710840/171409728-a6f97362-e4cf-4b04-b39b-b9a8b9de623e.png)



Also changed the placeholder positioning on desktop. Centered vertically against the filters, instead of vertically on the screen.

Before:
![image](https://user-images.githubusercontent.com/1710840/171410349-5a240657-0624-4303-acdf-071a78534188.png)

after:
![image](https://user-images.githubusercontent.com/1710840/171410384-ca581b7f-9761-4b13-bd0e-a37ad43a2c7f.png)

original design:
![image](https://user-images.githubusercontent.com/1710840/171410481-1022347f-2bf4-4c15-aca2-2b996bf67810.png)

