### PR TITLE
fix(arc-736): only show approved visitors, reset visit requests cache

### DIFF
--- a/src/modules/visits/hooks/update-visit.ts
+++ b/src/modules/visits/hooks/update-visit.ts
@@ -1,9 +1,15 @@
-import { useMutation, UseMutationResult } from 'react-query';
+import { QueryClient, useMutation, UseMutationResult } from 'react-query';
 
+import { QUERY_KEYS } from '@shared/const';
 import { Visit } from '@shared/types';
 import { VisitsService } from '@visits/services';
 import { UpdateVisit } from '@visits/types';
 
 export function useUpdateVisitRequest(): UseMutationResult<Visit, void, UpdateVisit> {
-	return useMutation(({ id, updatedProps }) => VisitsService.patchById(id, updatedProps));
+	return useMutation(({ id, updatedProps }) => VisitsService.patchById(id, updatedProps), {
+		onSuccess: async () => {
+			const queryClient = new QueryClient();
+			await queryClient.invalidateQueries(QUERY_KEYS.getVisits);
+		},
+	});
 }

--- a/src/pages/admin/bezoekersruimtesbeheer/actieve-bezoekers/index.tsx
+++ b/src/pages/admin/bezoekersruimtesbeheer/actieve-bezoekers/index.tsx
@@ -44,6 +44,7 @@ const Visitors: FC = () => {
 	} = useGetVisits({
 		searchInput: filters.search,
 		timeframe: VisitTimeframe.ACTIVE,
+		status: VisitStatus.APPROVED,
 		page: filters.page,
 		size: VisitorsTablePageSize,
 		orderProp: filters.orderProp as keyof Visit,


### PR DESCRIPTION
* Only show active visitors if their request was approved
* Clear the cache for visit requests when a visit mutation is triggered

![image](https://user-images.githubusercontent.com/1710840/171577742-b545c55b-4355-410c-9f32-94cd15e00a3f.png)
![image](https://user-images.githubusercontent.com/1710840/171577763-278ce810-33d3-4f1f-b17a-58502f600932.png)
