### PR TITLE
fix(arc-857): stop ui scroll on detail page

### DIFF
--- a/src/modules/shared/hooks/use-window-size/use-window-size.ts
+++ b/src/modules/shared/hooks/use-window-size/use-window-size.ts
@@ -19,6 +19,10 @@ const useWindowSize: UseWindowSize = () => {
 				width: window.innerWidth,
 				height: window.innerHeight,
 			});
+
+			// Set custom vh css var to exclude browser ui on mobile
+			const vh = window.innerHeight * 0.01;
+			document.documentElement.style.setProperty('--vh', `${vh}px`);
 		};
 		const debouncedResize = debounce(handleResize, WINDOW_RESIZE_TIMEOUT);
 

--- a/src/styles/layouts/_app.scss
+++ b/src/styles/layouts/_app.scss
@@ -7,8 +7,10 @@ $layout: "l-app";
 	min-height: 100vh;
 
 	&--sticky {
-		height: 100vh;
+		height: 100vh; // fallback for browsers that do not support custom css properties
+		height: calc((var(--vh, 1vh) * 100)); // '100vh' for mobile excludes browser ui. Custom --vh prop is set in use-window-size.ts
 		min-height: 72rem;
+		min-height: calc((var(--vh, 1vh) * 100));
 		overflow: hidden;
 
 		.#{$layout}__main {


### PR DESCRIPTION
- Prevent ui scroll on mobile browsers

⚠️  Test on real device or simulator

![image](https://user-images.githubusercontent.com/85545258/171617147-1cea6e75-73f1-41a3-b965-5c233136afd7.png)
