### PR TITLE
feat(arc-395): show outline on first tab element

### DIFF
--- a/src/styles/components/_tab.scss
+++ b/src/styles/components/_tab.scss
@@ -82,6 +82,7 @@ $component: "c-tab";
 		min-height: $tab-min-height-medium;
 
 		&:focus {
+			outline: $teal solid;
 			outline-offset: -6px;
 		}
 	}


### PR DESCRIPTION
[ARC-395](https://meemoo.atlassian.net/browse/ARC-395?focusedCommentId=31740)
- Betere outline voor de tabs zodat op safari het eerste item ook een outline krijgt na focus.
- Volledig niet kunnen tabben op Safari kan ik nog steeds niet reproduceren.

https://user-images.githubusercontent.com/85545258/171641408-4f1d2e43-042b-4a28-9fb3-6332198bcb95.mp4
