### PR TITLE
fix(arc-847): ensure active visitor indicator is always round

### DIFF
--- a/src/modules/shared/components/UnreadMarker/UnreadMarker.module.scss
+++ b/src/modules/shared/components/UnreadMarker/UnreadMarker.module.scss
@@ -5,6 +5,7 @@
 	background-color: $zinc;
 	width: 8px;
 	height: 8px;
+	min-width: 8px;
 	margin-right: 8px;
 	border-radius: 50%;
 


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-847

before and after:
![image](https://user-images.githubusercontent.com/1710840/172378678-fed46ffb-deda-4bf0-a6b5-e5a39fb132c0.png)
