### PR TITLE
fix(arc-444): add h6 styles and colored links in richTextEditor content

### DIFF
--- a/src/styles/abstracts/_variables.scss
+++ b/src/styles/abstracts/_variables.scss
@@ -67,6 +67,7 @@ $font-size-3xl: 4.8rem;
 $font-size-2xl: 4rem;
 $font-size-1xl: 3.2rem;
 $font-size-lg: 2.4rem;
+$font-size-2xm: 2.1rem;
 $font-size-md: 1.8rem;
 $font-size-base: 1.6rem;
 $font-size-sm: 1.4rem;

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -31,6 +31,11 @@ h4 {
 }
 
 h5 {
+	font-size: $font-size-2xm;
+	line-height: $line-height-base;
+}
+
+h6 {
 	font-size: $font-size-md;
 	line-height: $line-height-base;
 }

--- a/src/styles/pages/content-pages/_index.scss
+++ b/src/styles/pages/content-pages/_index.scss
@@ -1,1 +1,7 @@
 @use "button" as *;
+
+.c-content {
+	a {
+		color: #00c8aa;
+	}
+}


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-444

requires admin core PR: https://github.com/viaacode/react-admin-core-module/pull/29

![image](https://user-images.githubusercontent.com/1710840/172585831-16ddde26-4205-4c87-96a5-3c48742221e5.png)
![image](https://user-images.githubusercontent.com/1710840/172585846-c897ee26-b290-4ef7-993a-74ea959b615d.png)
