### PR TITLE
fix(arc-981): reset page when filters/sorting changes on search page

### DIFF
--- a/src/modules/visitor-space/components/VisitorSpaceSearchPage/VisitorSpaceSearchPage.tsx
+++ b/src/modules/visitor-space/components/VisitorSpaceSearchPage/VisitorSpaceSearchPage.tsx
@@ -164,7 +164,7 @@ const VisitorSpaceSearchPage: NextPage = () => {
 	const { data: media } = useGetMediaObjects(
 		visitorSpace?.maintainerId?.toLocaleLowerCase() as string,
 		mapFiltersToElastic(query),
-		query.page || 0,
+		query.page || 1,
 		VISITOR_SPACE_ITEM_COUNT,
 		activeSort,
 		visitorSpace?.maintainerId !== undefined
@@ -233,7 +233,7 @@ const VisitorSpaceSearchPage: NextPage = () => {
 
 	const onSearch = async (newValue: string) => {
 		if (newValue.trim() && !query.search?.includes(newValue)) {
-			setQuery({ [SEARCH_QUERY_KEY]: (query.search ?? []).concat(newValue) });
+			setQuery({ [SEARCH_QUERY_KEY]: (query.search ?? []).concat(newValue), page: 1 });
 		}
 	};
 
@@ -320,7 +320,7 @@ const VisitorSpaceSearchPage: NextPage = () => {
 				);
 
 				if (data.length === 0) {
-					setQuery({ [id]: undefined, filter: undefined });
+					setQuery({ [id]: undefined, filter: undefined, page: 1 });
 					return;
 				}
 
@@ -331,7 +331,7 @@ const VisitorSpaceSearchPage: NextPage = () => {
 				break;
 		}
 
-		setQuery({ [id]: data, filter: undefined });
+		setQuery({ [id]: data, filter: undefined, page: 1 });
 	};
 
 	const onRemoveTag = (tags: MultiValue<TagIdentity>) => {
@@ -370,14 +370,16 @@ const VisitorSpaceSearchPage: NextPage = () => {
 			...VISITOR_SPACE_QUERY_PARAM_INIT,
 		};
 
-		setQuery({ ...rest, ...query });
+		setQuery({ ...rest, ...query, page: 1 });
 	};
 
 	const onSortClick = (orderProp: string, orderDirection?: OrderDirection) => {
-		setQuery({ orderProp, orderDirection });
+		setQuery({ orderProp, orderDirection, page: 1 });
 	};
 
-	const onTabClick = (tabId: string | number) => setQuery({ format: String(tabId) });
+	const onTabClick = (tabId: string | number) => {
+		setQuery({ format: String(tabId), page: 1 });
+	};
 
 	const onViewToggle = (nextMode: string) => setViewMode(nextMode as MediaCardViewMode);
 
@@ -496,11 +498,11 @@ const VisitorSpaceSearchPage: NextPage = () => {
 				count={VISITOR_SPACE_ITEM_COUNT}
 				showBackToTop
 				total={getItemCounts(query.format as VisitorSpaceMediaType)}
-				onPageChange={(page) => {
+				onPageChange={(zeroBasedPage) => {
 					scrollTo(0);
 					setQuery({
 						...query,
-						page: page + 1,
+						page: zeroBasedPage + 1,
 					});
 				}}
 			/>


### PR DESCRIPTION
https://meemoo.atlassian.net/jira/software/c/projects/ARC/issues/ARC-981

cannot be tested locally because we do not have enough search results.

The problem:
Go to search on QAS en goto page 4
![image](https://user-images.githubusercontent.com/1710840/172627438-9379d2f7-2b10-4fc9-b964-cc11051a8cfa.png)

Scroll back to the top and add a filter:
![image](https://user-images.githubusercontent.com/1710840/172627491-8b731b3a-3c92-48b6-a45b-9a1fde237a31.png)

Scroll back down:
![image](https://user-images.githubusercontent.com/1710840/172627514-00664372-20cb-4709-8158-8100f8e26f3a.png)


Current result: the page is still on page 4

Desired result: the page is reset to page 1