### PR TITLE
fix(package.json): remove unused library: konva

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
 		"i18next-http-backend": "1.4.0",
 		"immer": "9.0.12",
 		"isomorphic-dompurify": "0.17.0",
-		"konva": "8.3.5",
 		"ky": "^0.30.0",
 		"ky-universal": "^0.10.1",
 		"lodash": "^4.17.21",


### PR DESCRIPTION
this was used as part of the waveform package, but we removed that dependency
and implemented the waveform rendering ourselves