### PR TITLE
fix(detail-page-error): safely get licenses if obj does not exist

### DIFF
--- a/src/pages/[slug]/[ie]/index.tsx
+++ b/src/pages/[slug]/[ie]/index.tsx
@@ -209,7 +209,7 @@ const ObjectDetailPage: NextPage = () => {
 		(mediaInfoError as HTTPError)?.response?.status === 404;
 	const isErrorSpaceNoAccess = (visitRequestError as HTTPError)?.response?.status === 403;
 	const isErrorNoLicense =
-		!hasMedia && !mediaInfo?.license.includes(License.BEZOEKERTOOL_CONTENT);
+		!hasMedia && !mediaInfo?.license?.includes(License.BEZOEKERTOOL_CONTENT);
 	const expandMetadata = activeTab === ObjectDetailTabs.Metadata;
 	const showFragmentSlider = representationsToDisplay.length > 1;
 	const isMobile = !!(windowSize.width && windowSize.width < Breakpoints.md);


### PR DESCRIPTION
go to this url without access to the space:
https://bezoek.hetarchief.be/vrt/00a22a093585457aaaf7116b9ae32e60a3cf03960ba549a5a87ac757970f541a395784b393be4d49a4e523b11c974c7c

currently: unexpected error => react crash on cannot read includes of undefined: license.includes(
![image](https://user-images.githubusercontent.com/1710840/174043979-814ceae4-a7b8-4654-a519-3ff4377cf858.png)

desired: you should see no access screen