### PR TITLE
fix(arc-1034): make copyright text smaller for content page image block

### DIFF
--- a/src/styles/pages/admin/_content-pages-preview.scss
+++ b/src/styles/pages/admin/_content-pages-preview.scss
@@ -68,9 +68,7 @@ $l-container-padding-xs: 2rem;
 		padding: 0 $spacer-sm;
 	}
 
-	div[style*="background-color: transparent"].content-block-preview-0:not(.c-content-page-preview
-			.c-content-page-preview
-			div[style*="background-color: transparent"].content-block-preview-0) {
+	div[style*="background-color: transparent"].content-block-preview-0:not(.c-content-page-preview .c-content-page-preview div[style*="background-color: transparent"].content-block-preview-0) {
 		background-color: $platinum !important; // override inline style
 		display: grid;
 		grid-template-columns: auto;
@@ -78,10 +76,7 @@ $l-container-padding-xs: 2rem;
 		align-items: center;
 
 		@include respond-at("lg") {
-			grid-template-columns: minmax($l-container-padding, 1fr) minmax(auto, 99.2rem) minmax(
-					$l-container-padding,
-					1fr
-				);
+			grid-template-columns: minmax($l-container-padding, 1fr) minmax(auto, 99.2rem) minmax($l-container-padding, 1fr);
 		}
 
 		.c-content-block-preview {
@@ -106,6 +101,18 @@ $l-container-padding-xs: 2rem;
 				height: 32rem;
 				background-image: radial-gradient(circle at 16rem, $platinum 16rem, $white 16rem);
 			}
+		}
+	}
+
+	// Image with copyright and description
+	.a-block-image__annotation {
+		h3 {
+			font-size: 1.8rem;
+			line-height: 3rem;
+		}
+
+		.a-block-image__text {
+			font-size: 1.6rem;
 		}
 	}
 }


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1034

before:
![image](https://user-images.githubusercontent.com/1710840/184299969-1729048d-5bd3-4b04-9d58-141e5b37df38.png)


after:
![image](https://user-images.githubusercontent.com/1710840/184299991-314886b2-57fe-4f44-880c-2da826758c2c.png)
