### PR TITLE
fix(arc-1082): hide filter labels for publish date

### DIFF
--- a/src/modules/visitor-space/components/PublishedFilterForm/PublishedFilterForm.tsx
+++ b/src/modules/visitor-space/components/PublishedFilterForm/PublishedFilterForm.tsx
@@ -83,7 +83,7 @@ const PublishedFilterForm: FC<PublishedFilterFormProps> = ({ children, className
 			<div className={clsx(className, 'u-px-20 u-px-32:md')}>
 				<div className="u-mb-32">
 					<FormControl
-						className="u-mb-24"
+						className="u-mb-24 c-form-control--label-hidden"
 						errors={[errors.operator?.message]}
 						id={labelKeys.operator}
 						label={t(
@@ -117,7 +117,7 @@ const PublishedFilterForm: FC<PublishedFilterFormProps> = ({ children, className
 					</FormControl>
 
 					<FormControl
-						className="u-mb-24"
+						className="u-mb-24 c-form-control--label-hidden"
 						errors={[errors.published?.message]}
 						id={labelKeys.published}
 						label={t(


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1082

before:
![image](https://user-images.githubusercontent.com/1710840/185936800-dc5f8a3d-0e75-41be-a437-5cea4f77c04c.png)


after:
![image](https://user-images.githubusercontent.com/1710840/185936828-6c999819-8ad3-48ed-a5c1-94a784683738.png)
