### PR TITLE
fix(arc-1061): avoid double scrollbar on item detail page on edge

### DIFF
--- a/src/styles/base/_root.scss
+++ b/src/styles/base/_root.scss
@@ -9,7 +9,10 @@ body {
 	font-size: $font-size-base;
 	line-height: $line-height-lg;
 	margin: 0;
-	overflow-y: scroll;
+	position: relative;
+	top: 0;
+	width: 100vw;
+	overflow-x: hidden;
 }
 
 *,


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1061

Dit scrollbar issue is nogal delicaat aangezien we specifiek die overflow scroll erin gestoken hebben om jumpen van de header menu items te vermijden.

Deze oplossing lijkt beter op chrome en edge, maar test het nog eens op mac (safari en chrome).

Er is vaak een jump bij initial page load, maar erna dan niet meer bij het toggelen van een menu.



before chrome & edge:

https://user-images.githubusercontent.com/1710840/186110893-fd8c6a55-bd85-43b1-bf96-afb5c253e36c.mp4



after chrome & edge:

https://user-images.githubusercontent.com/1710840/186110907-da4f5097-c90c-4ae7-9153-802d92afabf6.mp4


