### PR TITLE
fix(arc-1025): add and remove tab index on blade close button

### DIFF
--- a/src/modules/shared/components/Blade/Blade.tsx
+++ b/src/modules/shared/components/Blade/Blade.tsx
@@ -2,7 +2,7 @@ import { Button } from '@meemoo/react-components';
 import clsx from 'clsx';
 import FocusTrap from 'focus-trap-react';
 import { isUndefined } from 'lodash-es';
-import { FC } from 'react';
+import { FC, useEffect, useRef } from 'react';
 
 import { useBladeManagerContext } from '@shared/hooks/use-blade-manager-context';
 import { useScrollLock } from '@shared/hooks/use-scroll-lock';
@@ -28,9 +28,20 @@ const Blade: FC<BladeProps> = ({
 }) => {
 	const { isManaged, currentLayer, opacityStep, onCloseBlade } = useBladeManagerContext();
 	useScrollLock(!isManaged && isOpen, 'Blade');
+	const closeButtonRef = useRef<HTMLButtonElement | null>(null);
 
 	const isLayered = isManaged && layer;
 	const isBladeOpen = isLayered ? layer <= currentLayer : isOpen;
+
+	// Hack to remove ios outline on the close button: https://meemoo.atlassian.net/browse/ARC-1025
+	useEffect(() => {
+		if (isOpen) {
+			closeButtonRef.current?.setAttribute('tabIndex', '-1');
+			setTimeout(() => {
+				closeButtonRef.current?.removeAttribute('tabIndex');
+			}, 10);
+		}
+	}, [isOpen]);
 
 	const renderCloseButton = () => {
 		return (
@@ -48,6 +59,7 @@ const Blade: FC<BladeProps> = ({
 					}
 				}}
 				disabled={!isOpen}
+				buttonRef={closeButtonRef}
 			/>
 		);
 	};

--- a/src/modules/shared/components/Blade/Blade.tsx
+++ b/src/modules/shared/components/Blade/Blade.tsx
@@ -2,7 +2,7 @@ import { Button } from '@meemoo/react-components';
 import clsx from 'clsx';
 import FocusTrap from 'focus-trap-react';
 import { isUndefined } from 'lodash-es';
-import { FC, useEffect, useRef } from 'react';
+import { FC, useEffect } from 'react';
 
 import { useBladeManagerContext } from '@shared/hooks/use-blade-manager-context';
 import { useScrollLock } from '@shared/hooks/use-scroll-lock';
@@ -28,19 +28,13 @@ const Blade: FC<BladeProps> = ({
 }) => {
 	const { isManaged, currentLayer, opacityStep, onCloseBlade } = useBladeManagerContext();
 	useScrollLock(!isManaged && isOpen, 'Blade');
-	const closeButtonRef = useRef<HTMLButtonElement | null>(null);
 
 	const isLayered = isManaged && layer;
 	const isBladeOpen = isLayered ? layer <= currentLayer : isOpen;
 
 	// Hack to remove ios outline on the close button: https://meemoo.atlassian.net/browse/ARC-1025
 	useEffect(() => {
-		if (isOpen) {
-			closeButtonRef.current?.setAttribute('tabIndex', '-1');
-			setTimeout(() => {
-				closeButtonRef.current?.removeAttribute('tabIndex');
-			}, 10);
-		}
+		isOpen && (document.activeElement as HTMLElement)?.blur?.();
 	}, [isOpen]);
 
 	const renderCloseButton = () => {
@@ -59,7 +53,6 @@ const Blade: FC<BladeProps> = ({
 					}
 				}}
 				disabled={!isOpen}
-				buttonRef={closeButtonRef}
 			/>
 		);
 	};


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1025

Requires components PR: https://github.com/viaacode/react-components/pull/66

This PR adds a hack to attempt to hide the outline on the close button of the notification center blade on ios after opening the profile dropdown.

This hack has not been tested since i couldn't get the vpn to work with browserstack local. 
@ian-emsens-shd if you manage to get it working while testing this PR, let me know the settings?

![image](https://user-images.githubusercontent.com/1710840/186383772-55527576-4709-43c6-b5b6-b23b3c275ee3.png)
