### PR TITLE
fix(arc-1093): make date separator two dashes to avoid malformed dates

### DIFF
--- a/src/modules/shared/const/index.ts
+++ b/src/modules/shared/const/index.ts
@@ -6,4 +6,4 @@ export * from './sanitize';
 export * from './tos';
 
 export const SEARCH_QUERY_KEY = 'search';
-export const SEPARATOR = '-';
+export const SEPARATOR = '--';


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1093

dates before 1970 in unix format are negative, breaking the split on separator logic

when selecting 4 sept 1924:

before:
![image](https://user-images.githubusercontent.com/1710840/189660863-39da36d8-d15f-4b9d-92f6-b7c7b367d820.png)

after:
![image](https://user-images.githubusercontent.com/1710840/189660670-21058570-fc99-4050-a58d-d72872e8d248.png)
