### PR TITLE
fix(arc-885): show correct alternate name for object

### DIFF
--- a/src/modules/media/const/index.tsx
+++ b/src/modules/media/const/index.tsx
@@ -188,7 +188,7 @@ export const METADATA_FIELDS = (mediaInfo: Media): MetadataItem[] =>
 		},
 		{
 			title: i18n.t('modules/media/const/index___alternatieve-naam'),
-			data: mediaInfo.alternateName,
+			data: mapArrayToMetadataData(mediaInfo.alternativeName),
 		},
 		{
 			title: i18n.t('modules/media/const/index___archief'),

--- a/src/modules/media/types/index.ts
+++ b/src/modules/media/types/index.ts
@@ -9,7 +9,7 @@ export interface Media {
 	premisIsPartOf?: string;
 	series?: string[];
 	program?: string[];
-	alternativeName?: string;
+	alternativeName?: string[];
 	partOfArchive: string[];
 	partOfEpisode: string[];
 	partOfSeason: string[];


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-885

requires proxy PR: https://github.com/viaacode/hetarchief-proxy/pull/244

![image](https://user-images.githubusercontent.com/1710840/189669898-5a68177f-1448-4693-ad0a-978d30e7f78d.png)
![image](https://user-images.githubusercontent.com/1710840/189669923-39f3e1b2-637a-4359-a33b-1a1310b63386.png)
