### PR TITLE
fix(avo-542): fix server side rendering for object detail

### DIFF
--- a/src/modules/auth/wrappers/with-auth/with-auth.tsx
+++ b/src/modules/auth/wrappers/with-auth/with-auth.tsx
@@ -8,7 +8,7 @@ import Loading from '@shared/components/Loading/Loading';
 import { REDIRECT_TO_QUERY_KEY, ROUTES } from '@shared/const';
 import { useTermsOfService } from '@shared/hooks/use-terms-of-service';
 import { TosService } from '@shared/services/tos-service';
-import { isCurrentTosAccepted } from '@shared/utils';
+import { isBrowser, isCurrentTosAccepted } from '@shared/utils';
 
 export const withAuth = (WrappedComponent: ComponentType): ComponentType => {
 	return function ComponentWithAuth(props: Record<string, unknown>) {
@@ -53,6 +53,11 @@ export const withAuth = (WrappedComponent: ComponentType): ComponentType => {
 			checkLoginStatus();
 		}, [checkLoginStatus]);
 
-		return tosAccepted ? <WrappedComponent {...props} /> : <Loading fullscreen />;
+		// Allow server side rendering to get past this loading screen so we can determine seo fields on the actual page
+		return !isBrowser() || tosAccepted ? (
+			<WrappedComponent {...props} />
+		) : (
+			<Loading fullscreen />
+		);
 	};
 };

--- a/src/modules/media/services/media/media.service.ts
+++ b/src/modules/media/services/media/media.service.ts
@@ -82,7 +82,7 @@ export class MediaService {
 		return await ApiService.getApi().get(`${MEDIA_SERVICE_BASE_URL}/${id}`).json();
 	}
 
-	public static async getSeoById(id: string): Promise<{ title: string | null } | null> {
+	public static async getSeoById(id: string): Promise<{ name: string | null } | null> {
 		return await ApiService.getApi().get(`${MEDIA_SERVICE_BASE_URL}/seo/${id}`).json();
 	}
 

--- a/src/modules/media/services/media/media.service.ts
+++ b/src/modules/media/services/media/media.service.ts
@@ -82,6 +82,10 @@ export class MediaService {
 		return await ApiService.getApi().get(`${MEDIA_SERVICE_BASE_URL}/${id}`).json();
 	}
 
+	public static async getSeoById(id: string): Promise<{ title: string | null } | null> {
+		return await ApiService.getApi().get(`${MEDIA_SERVICE_BASE_URL}/seo/${id}`).json();
+	}
+
 	public static async getPlayableUrl(referenceId: string | null): Promise<string | null> {
 		if (!referenceId) {
 			return null;

--- a/src/modules/shared/helpers/render-og-tags.tsx
+++ b/src/modules/shared/helpers/render-og-tags.tsx
@@ -1,12 +1,15 @@
+import getConfig from 'next/config';
 import Head from 'next/head';
 import { ReactNode } from 'react';
 
 import { createPageTitle } from '@shared/utils';
 
+const { publicRuntimeConfig } = getConfig();
+
 export function renderOgTags(
 	title: string | undefined,
 	description: string,
-	clientUrl: string
+	url: string
 ): ReactNode {
 	const resolvedTitle = createPageTitle(title);
 	return (
@@ -14,12 +17,12 @@ export function renderOgTags(
 			<title>{resolvedTitle}</title>
 			<meta name="description" content={description} />
 			<meta property="og:type" content="website" />
-			<meta property="og:url" content={window.location.href} />
+			<meta property="og:url" content={url} />
 			<meta property="og:title" content={resolvedTitle} />
 			<meta property="og:description" content={description} />
-			<meta property="og:image" content={`${clientUrl}/images/og.jpg`} />
+			<meta property="og:image" content={`${publicRuntimeConfig.CLIENT_URL}/images/og.jpg`} />
 			<meta property="twitter:card" content="summary_large_image" />
-			<meta property="twitter:domain" content={window.location.origin} />
+			<meta property="twitter:domain" content={publicRuntimeConfig.CLIENT_URL} />
 			<meta property="twitter:title" content={resolvedTitle} />
 			<meta property="twitter:description" content={description} />
 		</Head>

--- a/src/modules/shared/hooks/use-element-size/use-element-size.ts
+++ b/src/modules/shared/hooks/use-element-size/use-element-size.ts
@@ -1,12 +1,14 @@
 import useResizeObserver from '@react-hook/resize-observer';
-import { useLayoutEffect, useState } from 'react';
+import { useState } from 'react';
+
+import useIsomorphicLayoutEffect from '@shared/hooks/use-isomorphic-layout-effect';
 
 import { UseElementSize } from './use-element-size.types';
 
 const useElementSize: UseElementSize = (target) => {
 	const [size, setSize] = useState<DOMRect>();
 
-	useLayoutEffect(() => {
+	useIsomorphicLayoutEffect(() => {
 		setSize(target.current?.getBoundingClientRect());
 	}, [target]);
 

--- a/src/modules/shared/hooks/use-isomorphic-layout-effect.ts
+++ b/src/modules/shared/hooks/use-isomorphic-layout-effect.ts
@@ -1,0 +1,13 @@
+import { useEffect, useLayoutEffect } from 'react';
+
+/**
+ * Use workaround to avoid warning about using useLayoutEffect inside Server Side Rendered components:
+ *
+ * Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer’s output format.
+ * This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this,
+ * useLayoutEffect should only be used in components that render exclusively on the client. See https://fb.me/react-uselayouteffect-ssr for common fixes.
+ *
+ * see: https://medium.com/@alexandereardon/uselayouteffect-and-ssr-192986cdcf7a
+ */
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+export default useIsomorphicLayoutEffect;

--- a/src/pages/[slug]/[ie]/index.tsx
+++ b/src/pages/[slug]/[ie]/index.tsx
@@ -817,7 +817,7 @@ const ObjectDetailPage: NextPage<ObjectDetailPageProps> = ({ title, url }) => {
 export async function getServerSideProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<ObjectDetailPageProps>> {
-	let seoInfo: { title: string | null } | null = null;
+	let seoInfo: { name: string | null } | null = null;
 	try {
 		seoInfo = await MediaService.getSeoById(context.query.ie as string);
 	} catch (err) {
@@ -826,7 +826,7 @@ export async function getServerSideProps(
 
 	return {
 		props: {
-			title: seoInfo?.title,
+			title: seoInfo?.name,
 			url: publicRuntimeConfig.CLIENT_URL + (context?.resolvedUrl || ''),
 			...(await withI18n()).props,
 		},


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-542

requires proxy PR: https://github.com/viaacode/hetarchief-proxy/pull/259

example url: http://localhost:3200/vlaams-parlement/d7d7841f8ad946f8bfa5116b30b9041ccec8fc5521d2404cab08b86c2d41466e231c382d924942de8d586b2f713e85f5

Server side rendered html now correctly contains the SEO tags like title, description, og tags
![image](https://user-images.githubusercontent.com/1710840/198310845-d237b2dd-6bed-44eb-9e6a-ff20c6709e7c.png)
![image](https://user-images.githubusercontent.com/1710840/198310881-191b6272-554f-4fed-9538-685a4a2d1970.png)


Switches SEO from client side to server side rendering for the object detail page.
This is a proof of concept. If you guys approve with the approach, ill apply it for all pages.