### PR TITLE
fix(arc-1279): move scrollbar right in read more description blade

### DIFF
--- a/src/modules/shared/components/MetaDataDescription/MetaDataDescription.module.scss
+++ b/src/modules/shared/components/MetaDataDescription/MetaDataDescription.module.scss
@@ -3,7 +3,7 @@
 $component: "c-metadatadescription";
 
 .#{$component} {
-	padding: $spacer-lg;
+	padding: $spacer-lg 0 $spacer-lg $spacer-lg;
 
 	&__title {
 		padding-bottom: $spacer-lg;
@@ -11,5 +11,9 @@ $component: "c-metadatadescription";
 
 	&__read-more {
 		cursor: pointer;
+	}
+
+	[class^="Blade_c-blade__body-wrapper"] {
+		padding-right: $spacer-lg;
 	}
 }


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1279

page: http://localhost:3200/zoeken/vlaams-parlement/d1288c82c96747d7bb6bd6260c4e2db14bcad026f9cf4add9376c22a5c06db421985e236d7fb4b839ffcf2fbe88606cf

on windows the scrollbar for the description of an object inside a blade is a bit strangely positioned:
![image](https://user-images.githubusercontent.com/1710840/220422493-d3f51ed8-1437-4730-a188-26d8667a85ff.png)

This PR fixes that:
![image](https://user-images.githubusercontent.com/1710840/220422547-12951ef0-d662-4c2a-9ab3-3a4168e5a84c.png)
