### PR TITLE
fix(translations): use translations in a function and no tHtml in text

### DIFF
--- a/src/modules/visitor-space/components/VisitorSpaceSearchPage/VisitorSpaceSearchPage.tsx
+++ b/src/modules/visitor-space/components/VisitorSpaceSearchPage/VisitorSpaceSearchPage.tsx
@@ -89,14 +89,14 @@ const labelKeys = {
 	search: 'VisitorSpaceSearchPage__search',
 };
 
-function getDefaultOption(): VisitorSpaceDropdownOption {
+const getDefaultOption = (): VisitorSpaceDropdownOption => {
 	return {
 		id: '',
 		label: tText(
 			'modules/visitor-space/components/visitor-space-search-page/visitor-space-search-page___pages-bezoekersruimte-publieke-catalogus'
 		),
 	};
-}
+};
 
 const VisitorSpaceSearchPage: FC = () => {
 	const { tHtml, tText } = useTranslation();

--- a/src/modules/visitor-space/components/VisitorSpaceSearchPage/VisitorSpaceSearchPage.tsx
+++ b/src/modules/visitor-space/components/VisitorSpaceSearchPage/VisitorSpaceSearchPage.tsx
@@ -35,7 +35,7 @@ import {
 	VisitorSpaceDropdownOption,
 } from '@shared/components';
 import { ROUTE_PARTS, SEARCH_QUERY_KEY } from '@shared/const';
-import { tHtml } from '@shared/helpers/translate';
+import { tText } from '@shared/helpers/translate';
 import { useHasAllPermission } from '@shared/hooks/has-permission';
 import { useScrollToId } from '@shared/hooks/scroll-to-id';
 import { useLocalStorage } from '@shared/hooks/use-localStorage/use-local-storage';
@@ -89,12 +89,14 @@ const labelKeys = {
 	search: 'VisitorSpaceSearchPage__search',
 };
 
-const defaultOption: VisitorSpaceDropdownOption = {
-	id: '',
-	label: `${tHtml(
-		'modules/visitor-space/components/visitor-space-search-page/visitor-space-search-page___pages-bezoekersruimte-publieke-catalogus'
-	)}`,
-};
+function getDefaultOption(): VisitorSpaceDropdownOption {
+	return {
+		id: '',
+		label: tText(
+			'modules/visitor-space/components/visitor-space-search-page/visitor-space-search-page___pages-bezoekersruimte-publieke-catalogus'
+		),
+	};
+}
 
 const VisitorSpaceSearchPage: FC = () => {
 	const { tHtml, tText } = useTranslation();
@@ -257,7 +259,7 @@ const VisitorSpaceSearchPage: FC = () => {
 			}
 		);
 
-		return [defaultOption, ...dynamicOptions];
+		return [getDefaultOption(), ...dynamicOptions];
 	}, [visitorSpaces, isMobile]);
 
 	/**


### PR DESCRIPTION
Translations provide 2 functions:
tHtml and tText

tText will output text
tHtml will output a ReactNode with the rendered html

So you cannot use tHtml inside a string


Also the translations need to be fetched from the backend before we can start translating strings, so you always need to fetch translations inside a function and never directly in a const variable on the file level, otherwise it won't correctly be translated.

eg:
```typescript
const myTranslation = tText(....) // wrong
const getMyTranslation = () => tText(...) // correct
```

before:
![image](https://user-images.githubusercontent.com/1710840/221161888-2307f8ae-0c52-49de-b6dc-5607d4b05910.png)

after:
![image](https://user-images.githubusercontent.com/1710840/221161838-9405f0e2-f1ba-407b-836d-7233c979c230.png)
