### PR TITLE
fix(routing): redirect to after login instead of /bezoek/some other path

### DIFF
--- a/src/modules/auth/services/auth-service/auth.service.ts
+++ b/src/modules/auth/services/auth-service/auth.service.ts
@@ -25,11 +25,14 @@ export class AuthService {
 		if ((originalPath || '').endsWith('/' + ROUTE_PARTS.logout)) {
 			originalPath = '/';
 		}
+		if (slug) {
+			originalPath = `/${ROUTE_PARTS.search}/${slug}`;
+		}
+		if ((originalPath || '') === ROUTES.home) {
+			originalPath = `/${ROUTE_PARTS.visit}`;
+		}
 		const returnToUrl = stringifyUrl({
-			url: trimEnd(
-				`${publicRuntimeConfig.CLIENT_URL}${ROUTES.bezoek}${originalPath ?? slug ?? ''}`,
-				'/'
-			),
+			url: trimEnd(`${publicRuntimeConfig.CLIENT_URL}${originalPath}`, '/'),
 			query: otherQueryParams,
 		});
 

--- a/src/modules/shared/const/routes.ts
+++ b/src/modules/shared/const/routes.ts
@@ -32,6 +32,7 @@ export const ROUTE_PARTS = Object.freeze({
 	myMaterialRequests: 'materiaalaanvragen',
 	search: 'zoeken',
 	visitors: 'bezoekers',
+	visit: 'bezoek',
 });
 
 // Note: Also used to set 'Bezoekersruimtes' active state if url does not start with any of the following prefixes


### PR DESCRIPTION
steps:
* be a logged out user
* click on search
* some requests fail because you need permissions (separate bug)
* you are shown the login modal
* login
* after login you are redirected to /bezoek/zoeken instead of /zoeken