### PR TITLE
fix: avoid 403 error on call for anonymous users

### DIFF
--- a/src/modules/visits/hooks/get-active-visit-for-user-and-space.ts
+++ b/src/modules/visits/hooks/get-active-visit-for-user-and-space.ts
@@ -1,16 +1,23 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 
+import { User } from '@auth/types';
 import { QUERY_KEYS } from '@shared/const/query-keys';
 import { Visit } from '@shared/types';
 import { VisitsService } from '@visits/services';
 
 export function useGetActiveVisitForUserAndSpace(
 	spaceId: string,
+	user: User | null | undefined,
 	enabled = true
 ): UseQueryResult<Visit> {
 	return useQuery(
-		[QUERY_KEYS.getActiveVisitForUserAndSpace, { spaceId }],
-		() => VisitsService.getActiveVisitForUserAndSpace(spaceId),
+		[QUERY_KEYS.getActiveVisitForUserAndSpace, { spaceId, user }],
+		() => {
+			if (!user) {
+				return null; // Anonymous users can never have an active visit request
+			}
+			return VisitsService.getActiveVisitForUserAndSpace(spaceId);
+		},
 		{ enabled, retry: 0 }
 	);
 }

--- a/src/pages/zoeken/[slug]/[ie]/index.tsx
+++ b/src/pages/zoeken/[slug]/[ie]/index.tsx
@@ -202,7 +202,7 @@ const ObjectDetailPage: NextPage<ObjectDetailPageProps> = ({ title, url }) => {
 		data: visitRequest,
 		error: visitRequestError,
 		isLoading: visitRequestIsLoading,
-	} = useGetActiveVisitForUserAndSpace(router.query.slug as string);
+	} = useGetActiveVisitForUserAndSpace(router.query.slug as string, user);
 
 	// get visitor space info, used to display contact information
 	const { data: visitorSpace, isLoading: visitorSpaceIsLoading } = useGetVisitorSpace(
@@ -904,4 +904,4 @@ export async function getServerSideProps(
 	};
 }
 
-export default withAuth(ObjectDetailPage as ComponentType);
+export default ObjectDetailPage;


### PR DESCRIPTION
No need to make a call to the api to check if a active visitor request exists, since we're an anonymous user, so the answer is be default: no

so we can immediately return null