### PR TITLE
feat(breadcrumbs): truncate breadcrumbs

### DIFF
--- a/src/styles/components/_breadcrumbs.scss
+++ b/src/styles/components/_breadcrumbs.scss
@@ -12,19 +12,12 @@
 		display: inline-flex;
 		align-items: center;
 		margin-bottom: $spacer-xxs;
-
-		p,
-		a {
-			overflow: hidden;
-			text-overflow: ellipsis;
-			display: flex;
-			-webkit-box-orient: vertical;
-		}
 	}
 
 	&__link {
 		font-size: $font-size-xs;
-		display: inline-flex;
+		/* stylelint-disable-next-line value-no-vendor-prefix */
+		display: -webkit-box;
 		justify-content: center;
 		align-items: center;
 		margin: 0 $spacer-xxs;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/77958553/226866993-47d23d65-7dd0-43a9-9e80-14363b3f1d62.png)
![image](https://user-images.githubusercontent.com/77958553/226867365-deb69b87-00b6-46e6-8b95-1cb19f5738d3.png)


Truncate breadcrumbs:
- default -> max length = 1 line
- active/last item -> max length = 2 lines