### PR TITLE
fix(navigation): remove rogue icon on the navigation item edit page

### DIFF
--- a/src/pages/admin/navigatie/[navigationBarId]/[navigationItemId]/bewerk/index.tsx
+++ b/src/pages/admin/navigatie/[navigationBarId]/[navigationItemId]/bewerk/index.tsx
@@ -24,8 +24,6 @@ const NavigationBarPageEditPage: FC<DefaultSeoInfo> = ({ url }) => {
 			<AdminLayout>
 				<AdminLayout.Content>
 					<div className="l-container p-admin-navigation__edit">
-						<Icon name={IconNamesLight.AngleDown} />
-
 						<NavigationEdit
 							navigationBarId={router.query.navigationBarId as string}
 							navigationItemId={router.query.navigationItemId as string}


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/1710840/226880477-5e82fb30-a82b-4ceb-8e66-df44338777d6.png)


after:
![image](https://user-images.githubusercontent.com/1710840/226880551-9bbf8450-31fd-4725-b108-4526b3fd4d5c.png)
