### PR TITLE
fix(arc-1526): enforce terms of service agreement before showing a page

### DIFF
--- a/src/modules/auth/wrappers/with-auth/with-auth.tsx
+++ b/src/modules/auth/wrappers/with-auth/with-auth.tsx
@@ -1,19 +1,33 @@
 import { useRouter } from 'next/router';
 import { stringify } from 'query-string';
-import { ComponentType, useCallback, useEffect } from 'react';
+import { ComponentType, useCallback, useEffect, useState } from 'react';
 
 import { AuthMessage, AuthService } from '@auth/services/auth-service';
 import { SHOW_AUTH_QUERY_KEY } from '@home/const';
 import Loading from '@shared/components/Loading/Loading';
 import { REDIRECT_TO_QUERY_KEY, ROUTES } from '@shared/const';
-import { useTermsOfService } from '@shared/hooks/use-terms-of-service';
 import { TosService } from '@shared/services/tos-service';
 import { isBrowser, isCurrentTosAccepted } from '@shared/utils';
 
-export const withAuth = (WrappedComponent: ComponentType): ComponentType => {
+/**
+ * Checks the users login status
+ * If the user is logged in
+ * 	- YES => check if he has accepted the latest version of the terms of service
+ * 	     - YES => show the page
+ * 	     - No  => show the terms of service
+ *  - NO  => is loginIsRequired true?
+ *       - YES => redirect user to homepage with login modal and redirection path to redirect the user after login
+ *       - NO  => show the requested page to the user
+ * @param WrappedComponent React component that renders the page
+ * @param isLoginRequired boolean
+ */
+export const withAuth = (
+	WrappedComponent: ComponentType,
+	isLoginRequired: boolean
+): ComponentType => {
 	return function ComponentWithAuth(props: Record<string, unknown>) {
 		const router = useRouter();
-		const tosAccepted = useTermsOfService();
+		const [showPage, setShowPage] = useState<boolean>(false);
 
 		const checkLoginStatus = useCallback(async (): Promise<void> => {
 			const login = await AuthService.checkLogin();
@@ -37,13 +51,21 @@ export const withAuth = (WrappedComponent: ComponentType): ComponentType => {
 			};
 
 			if (!login?.userInfo || login.message === AuthMessage.LoggedOut) {
-				// When the user isn't present in the response or the response states they've logged out
-				await toHome();
+				// User is logged out
+				if (isLoginRequired) {
+					// Login is required => redirect to home
+					await toHome();
+				} else {
+					// User is logged out, but the page can be seen without logging in
+					setShowPage(true);
+				}
 			} else {
-				// When the user is present in the response, they've not logged out
-
-				if (!isCurrentTosAccepted(login.userInfo.acceptedTosAt, tos?.updatedAt)) {
-					// When the user has not accepted the TOS or accepted a previous version of the TOS
+				// User is logged in
+				if (isCurrentTosAccepted(login.userInfo.acceptedTosAt, tos?.updatedAt)) {
+					// User has accepted the latest version of the terms of service
+					setShowPage(true);
+				} else {
+					// When the user has not accepted the TOS or accepted a previous version of the TOS => show terms of service
 					await toTermsOfService();
 				}
 			}
@@ -54,7 +76,7 @@ export const withAuth = (WrappedComponent: ComponentType): ComponentType => {
 		}, [checkLoginStatus]);
 
 		// Allow server side rendering to get past this loading screen, so we can determine seo fields on the actual page
-		return !isBrowser() || tosAccepted ? (
+		return !isBrowser() || showPage ? (
 			<WrappedComponent {...props} />
 		) : (
 			<Loading fullscreen owner="with auth" />

--- a/src/modules/home/components/LoggedInHome/LoggedInHome.tsx
+++ b/src/modules/home/components/LoggedInHome/LoggedInHome.tsx
@@ -436,4 +436,4 @@ const LoggedInHome: FC<DefaultSeoInfo> = ({ url }) => {
 	return renderHomePageContent();
 };
 
-export default withAuth(LoggedInHome as ComponentType) as FC<DefaultSeoInfo>;
+export default withAuth(LoggedInHome as ComponentType, true) as FC<DefaultSeoInfo>;

--- a/src/pages/[slug]/index.tsx
+++ b/src/pages/[slug]/index.tsx
@@ -4,10 +4,11 @@ import { GetServerSidePropsResult, NextPage } from 'next';
 import getConfig from 'next/config';
 import { useRouter } from 'next/router';
 import { GetServerSidePropsContext } from 'next/types';
-import { FC, useEffect } from 'react';
+import { ComponentType, FC, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { withAdminCoreConfig } from '@admin/wrappers/with-admin-core-config';
+import { withAuth } from '@auth/wrappers/with-auth';
 import { Loading } from '@shared/components';
 import { getDefaultServerSideProps } from '@shared/helpers/get-default-server-side-props';
 import { renderOgTags } from '@shared/helpers/render-og-tags';
@@ -123,5 +124,5 @@ export async function getServerSideProps(
 }
 
 export default withAdminCoreConfig(
-	withUser(DynamicRouteResolver as FC<unknown>)
+	withUser(withAuth(DynamicRouteResolver as ComponentType, false) as FC<unknown>)
 ) as FC<DefaultSeoInfo>;

--- a/src/pages/account/mijn-historiek/index.tsx
+++ b/src/pages/account/mijn-historiek/index.tsx
@@ -182,4 +182,4 @@ export async function getServerSideProps(
 	return getDefaultServerSideProps(context);
 }
 
-export default withAuth(AccountMyHistory as ComponentType);
+export default withAuth(AccountMyHistory as ComponentType, true);

--- a/src/pages/account/mijn-mappen/[folderSlug]/index.tsx
+++ b/src/pages/account/mijn-mappen/[folderSlug]/index.tsx
@@ -607,4 +607,4 @@ export async function getServerSideProps(
 	return getDefaultServerSideProps(context);
 }
 
-export default withAuth(AccountMyFolders as ComponentType);
+export default withAuth(AccountMyFolders as ComponentType, true);

--- a/src/pages/account/mijn-materiaalaanvragen/index.tsx
+++ b/src/pages/account/mijn-materiaalaanvragen/index.tsx
@@ -179,4 +179,4 @@ export async function getServerSideProps(
 	return getDefaultServerSideProps(context);
 }
 
-export default withAuth(AccountMyMaterialRequests as ComponentType);
+export default withAuth(AccountMyMaterialRequests as ComponentType, true);

--- a/src/pages/account/mijn-profiel/index.tsx
+++ b/src/pages/account/mijn-profiel/index.tsx
@@ -194,4 +194,4 @@ export async function getServerSideProps(
 	return getDefaultServerSideProps(context);
 }
 
-export default withAuth(AccountMyProfile as ComponentType);
+export default withAuth(AccountMyProfile as ComponentType, true);

--- a/src/pages/admin/bezoekersruimtesbeheer/actieve-bezoekers/index.tsx
+++ b/src/pages/admin/bezoekersruimtesbeheer/actieve-bezoekers/index.tsx
@@ -267,4 +267,4 @@ export async function getServerSideProps(
 	return getDefaultServerSideProps(context);
 }
 
-export default withAuth(Visitors as ComponentType);
+export default withAuth(Visitors as ComponentType, true);

--- a/src/pages/admin/bezoekersruimtesbeheer/bezoekersruimtes/[slug]/index.tsx
+++ b/src/pages/admin/bezoekersruimtesbeheer/bezoekersruimtes/[slug]/index.tsx
@@ -66,4 +66,4 @@ export async function getServerSideProps(
 	return getDefaultServerSideProps(context);
 }
 
-export default withAuth(VisitorSpaceEdit as ComponentType);
+export default withAuth(VisitorSpaceEdit as ComponentType, true);

--- a/src/pages/admin/bezoekersruimtesbeheer/bezoekersruimtes/index.tsx
+++ b/src/pages/admin/bezoekersruimtesbeheer/bezoekersruimtes/index.tsx
@@ -329,4 +329,4 @@ export async function getServerSideProps(
 	return getDefaultServerSideProps(context);
 }
 
-export default withAuth(VisitorSpacesOverview as ComponentType);
+export default withAuth(VisitorSpacesOverview as ComponentType, true);

--- a/src/pages/admin/bezoekersruimtesbeheer/bezoekersruimtes/maak/index.tsx
+++ b/src/pages/admin/bezoekersruimtesbeheer/bezoekersruimtes/maak/index.tsx
@@ -93,4 +93,4 @@ export async function getServerSideProps(
 	return getDefaultServerSideProps(context);
 }
 
-export default withAuth(VisitorSpaceCreate as ComponentType);
+export default withAuth(VisitorSpaceCreate as ComponentType, true);

--- a/src/pages/admin/bezoekersruimtesbeheer/toegangsaanvragen/index.tsx
+++ b/src/pages/admin/bezoekersruimtesbeheer/toegangsaanvragen/index.tsx
@@ -54,4 +54,4 @@ export async function getServerSideProps(
 	return getDefaultServerSideProps(context);
 }
 
-export default withAuth(MeemooAdminRequestsPage as ComponentType);
+export default withAuth(MeemooAdminRequestsPage as ComponentType, true);

--- a/src/pages/admin/content/[id]/bewerk/index.tsx
+++ b/src/pages/admin/content/[id]/bewerk/index.tsx
@@ -56,5 +56,6 @@ export async function getServerSideProps(
 }
 
 export default withAuth(
-	withAdminCoreConfig(withUser(ContentPageEditPage as FC<unknown>))
+	withAdminCoreConfig(withUser(ContentPageEditPage as FC<unknown>)),
+	true
 ) as FC<DefaultSeoInfo>;

--- a/src/pages/admin/content/[id]/index.tsx
+++ b/src/pages/admin/content/[id]/index.tsx
@@ -54,5 +54,6 @@ export async function getServerSideProps(
 }
 
 export default withAuth(
-	withAdminCoreConfig(withUser(ContentPageDetailPage as FC<unknown>))
+	withAdminCoreConfig(withUser(ContentPageDetailPage as FC<unknown>)),
+	true
 ) as FC<DefaultSeoInfo>;

--- a/src/pages/admin/content/index.tsx
+++ b/src/pages/admin/content/index.tsx
@@ -84,5 +84,6 @@ export async function getServerSideProps(
 }
 
 export default withAuth(
-	withAdminCoreConfig(withUser(ContentPageOverviewPage as FC<unknown>))
+	withAdminCoreConfig(withUser(ContentPageOverviewPage as FC<unknown>)),
+	true
 ) as FC<DefaultSeoInfo>;

--- a/src/pages/admin/content/maak/index.tsx
+++ b/src/pages/admin/content/maak/index.tsx
@@ -53,5 +53,6 @@ export async function getServerSideProps(
 }
 
 export default withAuth(
-	withAdminCoreConfig(withUser(ContentPageEditPage as FC<unknown>))
+	withAdminCoreConfig(withUser(ContentPageEditPage as FC<unknown>)),
+	true
 ) as FC<DefaultSeoInfo>;

--- a/src/pages/admin/gebruikersbeheer/gebruikers/index.tsx
+++ b/src/pages/admin/gebruikersbeheer/gebruikers/index.tsx
@@ -57,5 +57,6 @@ export async function getServerSideProps(
 }
 
 export default withAuth(
-	withAdminCoreConfig(withUser(UsersOverviewPage as FC<unknown>))
+	withAdminCoreConfig(withUser(UsersOverviewPage as FC<unknown>)),
+	true
 ) as FC<DefaultSeoInfo>;

--- a/src/pages/admin/gebruikersbeheer/permissies/index.tsx
+++ b/src/pages/admin/gebruikersbeheer/permissies/index.tsx
@@ -126,4 +126,4 @@ export async function getServerSideProps(
 	return getDefaultServerSideProps(context);
 }
 
-export default withAuth(withAdminCoreConfig(PermissionsOverview as ComponentType));
+export default withAuth(withAdminCoreConfig(PermissionsOverview as ComponentType), true);

--- a/src/pages/admin/materiaalaanvragen/index.tsx
+++ b/src/pages/admin/materiaalaanvragen/index.tsx
@@ -295,4 +295,4 @@ export async function getServerSideProps(
 	return getDefaultServerSideProps(context);
 }
 
-export default withAuth(AdminMaterialRequests as ComponentType);
+export default withAuth(AdminMaterialRequests as ComponentType, true);

--- a/src/pages/admin/meldingen/index.tsx
+++ b/src/pages/admin/meldingen/index.tsx
@@ -95,4 +95,4 @@ export async function getServerSideProps(
 	return getDefaultServerSideProps(context);
 }
 
-export default withAuth(withAdminCoreConfig(AdminAlertsOverview as ComponentType));
+export default withAuth(withAdminCoreConfig(AdminAlertsOverview as ComponentType), true);

--- a/src/pages/admin/navigatie/[navigationBarId]/[navigationItemId]/bewerk/index.tsx
+++ b/src/pages/admin/navigatie/[navigationBarId]/[navigationItemId]/bewerk/index.tsx
@@ -54,4 +54,4 @@ export async function getServerSideProps(
 	return getDefaultServerSideProps(context);
 }
 
-export default withAuth(withAdminCoreConfig(NavigationBarPageEditPage as ComponentType));
+export default withAuth(withAdminCoreConfig(NavigationBarPageEditPage as ComponentType), true);

--- a/src/pages/admin/navigatie/[navigationBarId]/index.tsx
+++ b/src/pages/admin/navigatie/[navigationBarId]/index.tsx
@@ -54,4 +54,4 @@ export async function getServerSideProps(
 	return getDefaultServerSideProps(context);
 }
 
-export default withAuth(withAdminCoreConfig(NavigationBarPageDetailPage as ComponentType));
+export default withAuth(withAdminCoreConfig(NavigationBarPageDetailPage as ComponentType), true);

--- a/src/pages/admin/navigatie/[navigationBarId]/maak/index.tsx
+++ b/src/pages/admin/navigatie/[navigationBarId]/maak/index.tsx
@@ -53,4 +53,4 @@ export async function getServerSideProps(
 	return getDefaultServerSideProps(context);
 }
 
-export default withAuth(withAdminCoreConfig(NavigationBarPageCreatePage as ComponentType));
+export default withAuth(withAdminCoreConfig(NavigationBarPageCreatePage as ComponentType), true);

--- a/src/pages/admin/navigatie/index.tsx
+++ b/src/pages/admin/navigatie/index.tsx
@@ -49,4 +49,4 @@ export async function getServerSideProps(
 	return getDefaultServerSideProps(context);
 }
 
-export default withAuth(withAdminCoreConfig(AdminNavigationOverview as ComponentType));
+export default withAuth(withAdminCoreConfig(AdminNavigationOverview as ComponentType), true);

--- a/src/pages/admin/navigatie/maak/index.tsx
+++ b/src/pages/admin/navigatie/maak/index.tsx
@@ -53,4 +53,4 @@ export async function getServerSideProps(
 	return getDefaultServerSideProps(context);
 }
 
-export default withAuth(withAdminCoreConfig(NavigationPageCreatePage as ComponentType));
+export default withAuth(withAdminCoreConfig(NavigationPageCreatePage as ComponentType), true);

--- a/src/pages/admin/vertalingen/index.tsx
+++ b/src/pages/admin/vertalingen/index.tsx
@@ -106,4 +106,4 @@ export async function getServerSideProps(
 	return getDefaultServerSideProps(context);
 }
 
-export default withAuth(withAdminCoreConfig(AdminTranslationsOverview as ComponentType));
+export default withAuth(withAdminCoreConfig(AdminTranslationsOverview as ComponentType), true);

--- a/src/pages/beheer/bezoekers/index.tsx
+++ b/src/pages/beheer/bezoekers/index.tsx
@@ -303,4 +303,4 @@ export async function getServerSideProps(
 	return getDefaultServerSideProps(context);
 }
 
-export default withAuth(CPVisitorsPage as ComponentType);
+export default withAuth(CPVisitorsPage as ComponentType, true);

--- a/src/pages/beheer/instellingen/index.tsx
+++ b/src/pages/beheer/instellingen/index.tsx
@@ -88,4 +88,4 @@ export async function getServerSideProps(
 	return getDefaultServerSideProps(context);
 }
 
-export default withAuth(CPSettingsPage as ComponentType);
+export default withAuth(CPSettingsPage as ComponentType, true);

--- a/src/pages/beheer/materiaalaanvragen/index.tsx
+++ b/src/pages/beheer/materiaalaanvragen/index.tsx
@@ -254,4 +254,4 @@ export async function getServerSideProps(
 	return getDefaultServerSideProps(context);
 }
 
-export default withAuth(CPMaterialRequestsPage as ComponentType);
+export default withAuth(CPMaterialRequestsPage as ComponentType, true);

--- a/src/pages/beheer/toegangsaanvragen/index.tsx
+++ b/src/pages/beheer/toegangsaanvragen/index.tsx
@@ -48,4 +48,4 @@ export async function getServerSideProps(
 	return getDefaultServerSideProps(context);
 }
 
-export default withAuth(CPRequestsPage as ComponentType);
+export default withAuth(CPRequestsPage as ComponentType, true);

--- a/src/pages/bezoek/[slug]/toegang-aangevraagd/index.tsx
+++ b/src/pages/bezoek/[slug]/toegang-aangevraagd/index.tsx
@@ -136,4 +136,4 @@ export async function getServerSideProps(
 	};
 }
 
-export default withAuth(VisitRequestedPage as ComponentType);
+export default withAuth(VisitRequestedPage as ComponentType, true);

--- a/src/pages/gebruiksvoorwaarden/index.tsx
+++ b/src/pages/gebruiksvoorwaarden/index.tsx
@@ -71,24 +71,14 @@ const TermsOfService: NextPage<DefaultSeoInfo & UserProps> = ({ url, commonUser 
 	const onConfirmClick = () => {
 		if (user) {
 			TosService.acceptTos(user?.id).then((updated) => {
-				dispatch(checkLoginAction());
-
-				if (updated.acceptedTosAt) {
-					// Execute in separate cycle
-					setTimeout(() =>
-						router.push(query[REDIRECT_TO_QUERY_KEY]).then(() => {
-							toastService.notify({
-								title: tHtml(
-									'pages/gebruiksvoorwaarden/index___gebruiksvoorwaarden-aanvaard'
-								),
-								description: tHtml(
-									'pages/gebruiksvoorwaarden/index___je-geniet-nu-van-volledige-toegang-tot-het-platform'
-								),
-								maxLines: 2,
-							});
-						})
-					);
-				}
+				router.push(query[REDIRECT_TO_QUERY_KEY]);
+				toastService.notify({
+					title: tHtml('pages/gebruiksvoorwaarden/index___gebruiksvoorwaarden-aanvaard'),
+					description: tHtml(
+						'pages/gebruiksvoorwaarden/index___je-geniet-nu-van-volledige-toegang-tot-het-platform'
+					),
+					maxLines: 2,
+				});
 			});
 		}
 	};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,10 @@
 import { ContentPageRenderer } from '@meemoo/admin-core-ui';
 import { GetServerSidePropsResult, NextPage } from 'next';
 import { GetServerSidePropsContext } from 'next/types';
-import { FC } from 'react';
+import { ComponentType, FC } from 'react';
 
 import { withAdminCoreConfig } from '@admin/wrappers/with-admin-core-config';
+import { withAuth } from '@auth/wrappers/with-auth';
 import { Loading } from '@shared/components';
 import { getDefaultServerSideProps } from '@shared/helpers/get-default-server-side-props';
 import { renderOgTags } from '@shared/helpers/render-og-tags';
@@ -72,4 +73,6 @@ export async function getServerSideProps(
 	};
 }
 
-export default withAdminCoreConfig(withUser(Homepage as FC<unknown>)) as FC<HomepageProps>;
+export default withAdminCoreConfig(
+	withUser(withAuth(Homepage as ComponentType, false) as FC<unknown>)
+) as FC<HomepageProps>;

--- a/src/pages/zoeken/index.tsx
+++ b/src/pages/zoeken/index.tsx
@@ -1,7 +1,8 @@
 import { GetServerSidePropsContext, GetServerSidePropsResult, NextPage } from 'next';
-import { useEffect } from 'react';
+import { ComponentType, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 
+import { withAuth } from '@auth/wrappers/with-auth';
 import { getDefaultServerSideProps } from '@shared/helpers/get-default-server-side-props';
 import { setShowZendesk } from '@shared/store/ui';
 import { DefaultSeoInfo } from '@shared/types/seo';
@@ -29,4 +30,4 @@ export async function getServerSideProps(
 	return getDefaultServerSideProps(context);
 }
 
-export default SearchPage;
+export default withAuth(SearchPage as ComponentType, false);


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1526

Show terms of service after the user logs in


https://user-images.githubusercontent.com/1710840/228284942-819c923f-0389-424b-9858-12c2e29f66ef.mp4



You can set your "accepted tos date" through the swagger page: http://localhost:3100/docs/#/Users/UsersController_updateTos

The id is the id of the user. for the meemoo admin this is: c4dead9b-32c3-4459-a66b-23f73afba3ea

The body should be:
```
{
  "acceptedTosAt": "2020-02-22T08:50:47.482Z"
}
```

![image](https://user-images.githubusercontent.com/1710840/229100946-85f07096-d5cf-4689-89fc-10268e793aa4.png)



