### PR TITLE
feature/ARC- 1282: Highlight title and description on object detail page

### DIFF
--- a/src/modules/ie-objects/const/index.tsx
+++ b/src/modules/ie-objects/const/index.tsx
@@ -1,4 +1,5 @@
 import { MenuItemInfo, TabProps } from '@meemoo/react-components';
+import { ArrayParam } from 'use-query-params';
 
 import {
 	ActionItem,
@@ -387,3 +388,7 @@ export const METADATA_FIELDS = (
 		) : null,
 	},
 ];
+
+export const IE_OBJECT_QUERY_PARAM_CONFIG = {
+	searchTerms: ArrayParam,
+};

--- a/src/modules/shared/components/MediaCardList/MediaCardList.tsx
+++ b/src/modules/shared/components/MediaCardList/MediaCardList.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import { stringifyUrl } from 'query-string';
 import { FC, memo, ReactNode } from 'react';
 import Masonry from 'react-masonry-css';
 import { useSelector } from 'react-redux';
@@ -158,8 +159,14 @@ const MediaCardList: FC<MediaCardListProps> = ({
 		return false;
 	};
 
-	const tiles = items.map((item, i) =>
-		wrapper(
+	const tiles = items.map((item, i) => {
+		const link = stringifyUrl({
+			url: `/${ROUTE_PARTS.search}/${item.maintainerSlug}/${item.schemaIdentifier}`,
+			query: {
+				searchTerms: keywords,
+			},
+		});
+		return wrapper(
 			<MediaCard
 				key={getKey(item, i)}
 				id={getKey(item, i)}
@@ -170,12 +177,13 @@ const MediaCardList: FC<MediaCardListProps> = ({
 				keywords={keywords}
 				view={view}
 				showLocallyAvailable={showLocallyAvailable && checkLocallyAvailable(item)}
-				link={`/${ROUTE_PARTS.search}/${item.maintainerSlug}/${item.schemaIdentifier}`}
+				link={link}
 				maintainerSlug={item.maintainerSlug}
 			/>,
 			item
-		)
-	);
+		);
+	});
+
 	return (
 		<div
 			className={clsx(

--- a/src/modules/shared/components/MetaDataDescription/MetaDataDescription.tsx
+++ b/src/modules/shared/components/MetaDataDescription/MetaDataDescription.tsx
@@ -1,10 +1,12 @@
 import clsx from 'clsx';
 import { FC, useMemo, useState } from 'react';
+import Highlighter from 'react-highlight-words';
+import { useQueryParams } from 'use-query-params';
 
+import { IE_OBJECT_QUERY_PARAM_CONFIG } from '@ie-objects/const';
 import useTranslation from '@shared/hooks/use-translation/use-translation';
 
 import { Blade } from '../Blade';
-import { TextWithNewLines } from '../TextWithNewLines';
 
 import { DESCRIPTION_MAX_LENGTH } from './MetaDataDescription.const';
 import styles from './MetaDataDescription.module.scss';
@@ -30,10 +32,22 @@ const MetaDataDescription: FC<MetaDataDescriptionProps> = ({ description }) => {
 		</h3>
 	);
 
+	const [query] = useQueryParams(IE_OBJECT_QUERY_PARAM_CONFIG);
+
+	const highlighted = (toHighlight: string) => (
+		<Highlighter
+			searchWords={(query.searchTerms as string[]) ?? []}
+			autoEscape={true}
+			textToHighlight={toHighlight}
+		/>
+	);
+
 	return (
 		<>
 			<p className="u-pb-24 u-line-height-1-4 u-font-size-14">
-				<TextWithNewLines text={parsedDescription} />
+				{/* ARC-1282: if there are issues with showing \\n or not showing new lines,
+				the parsedDescription used to be in a <TextWithNewLines /> component. This component was removed here to highlight text */}
+				{highlighted(parsedDescription.replaceAll('\\n', ' ').replaceAll('\n', ' '))}
 				{isLongDescription && (
 					<u
 						className={styles['c-metadatadescription__read-more']}
@@ -52,7 +66,7 @@ const MetaDataDescription: FC<MetaDataDescriptionProps> = ({ description }) => {
 				onClose={() => setIsBladeOpen(false)}
 				renderTitle={renderBladeTitle}
 			>
-				{description}
+				{highlighted(description)}
 			</Blade>
 		</>
 	);

--- a/src/pages/zoeken/[slug]/[ie]/index.tsx
+++ b/src/pages/zoeken/[slug]/[ie]/index.tsx
@@ -23,8 +23,10 @@ import { useRouter } from 'next/router';
 import { GetServerSidePropsContext } from 'next/types';
 import { stringifyUrl } from 'query-string';
 import { Fragment, ReactNode, useEffect, useMemo, useState } from 'react';
+import Highlighter from 'react-highlight-words';
 import { useDispatch, useSelector } from 'react-redux';
 import save from 'save-file';
+import { useQueryParams } from 'use-query-params';
 
 import { GroupName, Permission } from '@account/const';
 import { selectUser } from '@auth/store/user';
@@ -45,6 +47,7 @@ import {
 	FLOWPLAYER_AUDIO_FORMATS,
 	FLOWPLAYER_VIDEO_FORMATS,
 	formatErrorPlaceholder,
+	IE_OBJECT_QUERY_PARAM_CONFIG,
 	IMAGE_FORMATS,
 	MEDIA_ACTIONS,
 	METADATA_EXPORT_OPTIONS,
@@ -147,6 +150,10 @@ const ObjectDetailPage: NextPage<ObjectDetailPageProps> = ({ title, url }) => {
 		GroupName.VISITOR,
 		GroupName.ANONYMOUS
 	);
+
+	const [query] = useQueryParams(IE_OBJECT_QUERY_PARAM_CONFIG);
+
+	console.log(query.searchTerms);
 
 	// Internal state
 	const [activeTab, setActiveTab] = useState<string | number | null>(null);
@@ -503,6 +510,14 @@ const ObjectDetailPage: NextPage<ObjectDetailPageProps> = ({ title, url }) => {
 			});
 		}
 	};
+
+	const highlighted = (toHighlight: string) => (
+		<Highlighter
+			searchWords={(query.searchTerms as string[]) ?? []}
+			autoEscape={true}
+			textToHighlight={toHighlight}
+		/>
+	);
 
 	/**
 	 * Content
@@ -905,7 +920,7 @@ const ObjectDetailPage: NextPage<ObjectDetailPageProps> = ({ title, url }) => {
 							showKeyUserPill ? 'u-pt-8' : 'u-pt-24'
 						)}
 					>
-						{mediaInfo?.name}
+						{highlighted(mediaInfo?.name)}
 					</h3>
 
 					{renderMetaDataActions()}

--- a/src/pages/zoeken/[slug]/[ie]/index.tsx
+++ b/src/pages/zoeken/[slug]/[ie]/index.tsx
@@ -153,8 +153,6 @@ const ObjectDetailPage: NextPage<ObjectDetailPageProps> = ({ title, url }) => {
 
 	const [query] = useQueryParams(IE_OBJECT_QUERY_PARAM_CONFIG);
 
-	console.log(query.searchTerms);
-
 	// Internal state
 	const [activeTab, setActiveTab] = useState<string | number | null>(null);
 	const [activeBlade, setActiveBlade] = useState<MediaActions | null>(null);


### PR DESCRIPTION
<img width="1067" alt="image" src="https://user-images.githubusercontent.com/113892598/230330706-6525c80d-f412-4669-b201-4bab397c2d04.png">
<img width="1079" alt="image" src="https://user-images.githubusercontent.com/113892598/230330830-fbc5e60f-0efc-42a0-9065-01c57f497d62.png">
<img width="1062" alt="image" src="https://user-images.githubusercontent.com/113892598/230330898-3981150e-5e42-4100-9529-6be139247522.png">
Ticket: https://meemoo.atlassian.net/browse/ARC-1282
(ondertitels en transcriptie zit er niet bij, beslist door Christophe)