### PR TITLE
feat(ie): show simplified maintainer metadata for kiosk users

### DIFF
--- a/src/modules/ie-objects/const/index.tsx
+++ b/src/modules/ie-objects/const/index.tsx
@@ -303,16 +303,12 @@ export enum CustomMetaDataFields {
 }
 
 // TODO: complete mapping
-export const METADATA_FIELDS = (
-	mediaInfo: IeObject,
-	showExtendedMaintainer: boolean
-): MetadataItem[] => [
+export const METADATA_FIELDS = (mediaInfo: IeObject): MetadataItem[] => [
 	{
 		title: CustomMetaDataFields.Maintainer,
 		data: CustomMetaDataFields.Maintainer,
 		customData: true,
 		customTitle: true,
-		isDisabled: () => !showExtendedMaintainer,
 	},
 	{
 		title: tText('modules/ie-objects/const/index___oorsprong'),

--- a/src/pages/zoeken/[slug]/[ie]/index.tsx
+++ b/src/pages/zoeken/[slug]/[ie]/index.tsx
@@ -883,32 +883,36 @@ const ObjectDetailPage: NextPage<ObjectDetailPageProps> = ({ title, url }) => {
 			<p className="p-object-detail__metadata-label">
 				{tText('modules/ie-objects/const/index___aanbieder')}
 			</p>
-			<p className="p-object-detail__metadata-pill">
-				<TagList
-					className="u-pt-12"
-					tags={mapKeywordsToTags([maintainerName])}
-					onTagClicked={(keyword: string | number) => {
-						router.push(
-							stringifyUrl({
-								url: `/${ROUTE_PARTS.search}`,
-								query: {
-									[VisitorSpaceFilterId.Maintainers]: [`${keyword}`],
-								},
-							})
-						);
-					}}
-					variants={['clickable', 'silver', 'medium']}
-				/>
-			</p>
-			{maintainerLogo && (
-				<div className="p-object-detail__metadata-logo">
-					<Image
-						src={maintainerLogo}
-						alt={`Logo ${maintainerName}`}
-						layout="fill"
-						objectFit="contain"
-					/>
-				</div>
+			{isNotKiosk && (
+				<>
+					<p className="p-object-detail__metadata-pill">
+						<TagList
+							className="u-pt-12"
+							tags={mapKeywordsToTags([maintainerName])}
+							onTagClicked={(keyword: string | number) => {
+								router.push(
+									stringifyUrl({
+										url: `/${ROUTE_PARTS.search}`,
+										query: {
+											[VisitorSpaceFilterId.Maintainers]: [`${keyword}`],
+										},
+									})
+								);
+							}}
+							variants={['clickable', 'silver', 'medium']}
+						/>
+					</p>
+					{maintainerLogo && (
+						<div className="p-object-detail__metadata-logo">
+							<Image
+								src={maintainerLogo}
+								alt={`Logo ${maintainerName}`}
+								layout="fill"
+								objectFit="contain"
+							/>
+						</div>
+					)}
+				</>
 			)}
 		</div>
 	);
@@ -924,21 +928,25 @@ const ObjectDetailPage: NextPage<ObjectDetailPageProps> = ({ title, url }) => {
 	const renderMaintainerMetaData = ({
 		maintainerDescription,
 		maintainerSiteUrl,
-	}: IeObject): ReactNode => (
-		<div className="p-object-detail__metadata-maintainer-data">
-			{maintainerDescription && (
-				<p className="p-object-detail__metadata-description">{maintainerDescription}</p>
-			)}
-			{maintainerSiteUrl && (
-				<p className="p-object-detail__metadata-link">
-					<a href={maintainerSiteUrl} target="_blank" rel="noopener noreferrer">
-						{maintainerSiteUrl}
-					</a>
-					<Icon className="u-ml-8" name={IconNamesLight.Extern} />
-				</p>
-			)}
-		</div>
-	);
+		maintainerName,
+	}: IeObject): ReactNode =>
+		isNotKiosk ? (
+			<div className="p-object-detail__metadata-maintainer-data">
+				{maintainerDescription && (
+					<p className="p-object-detail__metadata-description">{maintainerDescription}</p>
+				)}
+				{maintainerSiteUrl && (
+					<p className="p-object-detail__metadata-link">
+						<a href={maintainerSiteUrl} target="_blank" rel="noopener noreferrer">
+							{maintainerSiteUrl}
+						</a>
+						<Icon className="u-ml-8" name={IconNamesLight.Extern} />
+					</p>
+				)}
+			</div>
+		) : (
+			<div className="p-object-detail__metadata-maintainer-data">{maintainerName}</div>
+		);
 
 	const getCustomTitleRenderFn = (
 		field: CustomMetaDataFields,

--- a/src/pages/zoeken/[slug]/[ie]/index.tsx
+++ b/src/pages/zoeken/[slug]/[ie]/index.tsx
@@ -883,7 +883,7 @@ const ObjectDetailPage: NextPage<ObjectDetailPageProps> = ({ title, url }) => {
 			<p className="p-object-detail__metadata-label">
 				{tText('modules/ie-objects/const/index___aanbieder')}
 			</p>
-			{isNotKiosk && (
+			{isNotKiosk && !hasAccessToVisitorSpaceOfObject && (
 				<>
 					<p className="p-object-detail__metadata-pill">
 						<TagList
@@ -930,7 +930,7 @@ const ObjectDetailPage: NextPage<ObjectDetailPageProps> = ({ title, url }) => {
 		maintainerSiteUrl,
 		maintainerName,
 	}: IeObject): ReactNode =>
-		isNotKiosk ? (
+		isNotKiosk && !hasAccessToVisitorSpaceOfObject ? (
 			<div className="p-object-detail__metadata-maintainer-data">
 				{maintainerDescription && (
 					<p className="p-object-detail__metadata-description">{maintainerDescription}</p>
@@ -990,8 +990,7 @@ const ObjectDetailPage: NextPage<ObjectDetailPageProps> = ({ title, url }) => {
 		}
 
 		const showAlert = !mediaInfo.description;
-		const showExtendedMaintainer = !hasAccessToVisitorSpaceOfObject && isNotKiosk;
-		const metaDataFields = METADATA_FIELDS(mediaInfo, showExtendedMaintainer)
+		const metaDataFields = METADATA_FIELDS(mediaInfo)
 			.filter(({ isDisabled }: MetadataItem): boolean => !isDisabled?.())
 			.map(
 				(field: MetadataItem): MetadataItem => ({


### PR DESCRIPTION
**Kiosk users || all other users when no access to the space of the current object**
<img width="880" alt="image" src="https://user-images.githubusercontent.com/77958553/230372596-23fb390c-d858-442f-a8af-c1b381ed16e6.png">

**All other users when given access to the space of the current object**
<img width="877" alt="image" src="https://user-images.githubusercontent.com/77958553/230372448-efc61d02-16a3-4f41-8334-2aaec3140e6f.png">

**To test**
Can't be tested by using a kiosk account since there's something wrong with the acc. You can test this by inverting the `isNotKiosk` boolean in `renderMaintainerMetaTitle` and `renderMaintainerMetaData`. 
