### PR TITLE
Feature/arc 1190

### DIFF
--- a/src/modules/account/const/index.tsx
+++ b/src/modules/account/const/index.tsx
@@ -1,10 +1,19 @@
 import { ReactNode } from 'react';
+import { boolean, object, SchemaOf } from 'yup';
 
+import { CommunicationFormState } from '@account/types';
 import { tHtml, tText } from '@shared/helpers/translate';
 
 export * from './my-collections.const';
 export * from './my-history.const';
 export * from './my-material-requests.const';
+
+export const COMMUNICATION_FORM_SCHEMA = (): SchemaOf<CommunicationFormState> =>
+	object({
+		acceptNewsletter: boolean().required(
+			tText('modules/account/const/account___ik-ontvang-graag-de-nieuwsbrief-is-verplicht')
+		),
+	});
 
 export const ACCOUNT_NAVIGATION_LINKS = (): {
 	id: string;

--- a/src/modules/account/hooks/get-newsletter-preferences.ts
+++ b/src/modules/account/hooks/get-newsletter-preferences.ts
@@ -1,0 +1,22 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { isEmpty, isNil } from 'lodash-es';
+
+import { GetNewsletterPreferencesResponse } from '@account/types';
+import { QUERY_KEYS } from '@shared/const/query-keys';
+import { CampaignMonitorService } from '@shared/services/campaign-monitor-service';
+
+export const useGetNewsletterPreferences = (
+	email: string | undefined
+): UseQueryResult<GetNewsletterPreferencesResponse | null> => {
+	return useQuery([QUERY_KEYS.getNewsletterPreferences, { email }], () => {
+		if (isNil(email)) {
+			return null;
+		}
+
+		if (isEmpty(email)) {
+			throw new Error(`Given email can't be empty. Received email: ${email}`);
+		}
+
+		return CampaignMonitorService.getPreferences(email);
+	});
+};

--- a/src/modules/account/types/account.ts
+++ b/src/modules/account/types/account.ts
@@ -1,3 +1,6 @@
+export interface CommunicationFormState {
+	acceptNewsletter: boolean;
+}
 
 export interface GetNewsletterPreferencesResponse {
 	newsletter: boolean;

--- a/src/modules/account/types/account.ts
+++ b/src/modules/account/types/account.ts
@@ -1,0 +1,11 @@
+
+export interface GetNewsletterPreferencesResponse {
+	newsletter: boolean;
+}
+
+export interface SetNewsletterPreferencesBody {
+	firstName: string;
+	lastName: string;
+	mail: string;
+	preferences: GetNewsletterPreferencesResponse;
+}

--- a/src/modules/account/types/account.ts
+++ b/src/modules/account/types/account.ts
@@ -7,8 +7,8 @@ export interface GetNewsletterPreferencesResponse {
 }
 
 export interface SetNewsletterPreferencesBody {
-	firstName: string;
-	lastName: string;
-	mail: string;
+	firstName?: string;
+	lastName?: string;
+	mail?: string;
 	preferences: GetNewsletterPreferencesResponse;
 }

--- a/src/modules/account/types/index.ts
+++ b/src/modules/account/types/index.ts
@@ -1,1 +1,2 @@
 export * from './collections';
+export * from './account';

--- a/src/modules/shared/const/query-keys.ts
+++ b/src/modules/shared/const/query-keys.ts
@@ -27,4 +27,5 @@ export enum QUERY_KEYS {
 	getMaterialRequests = 'getMaterialRequests',
 	getMaterialRequestById = 'getMaterialRequestById',
 	getMaintenanceAlerts = 'getMaintenanceAlerts',
+	getNewsletterPreferences = 'getNewsletterPreferences',
 }

--- a/src/modules/shared/services/campaign-monitor-service/campaign-monitor.consts.ts
+++ b/src/modules/shared/services/campaign-monitor-service/campaign-monitor.consts.ts
@@ -1,0 +1,4 @@
+export const CAMPAIGN_MONITOR_SERVICE_BASE_URL = 'campaign-monitor';
+
+export const CAMPAIGN_MONITOR_SERVICE_PREFERENCES = 'preferences';
+export const CAMPAIGN_MONITOR_SERVICE_SEND = 'send';

--- a/src/modules/shared/services/campaign-monitor-service/campaign-monitor.service.ts
+++ b/src/modules/shared/services/campaign-monitor-service/campaign-monitor.service.ts
@@ -1,8 +1,40 @@
+import { stringifyUrl } from 'query-string';
+
+import { GetNewsletterPreferencesResponse, SetNewsletterPreferencesBody } from '@account/types';
 import { EmailTemplate } from '@shared/components/ShareFolderBlade/ShareFolderBlade.consts';
 import { ApiService } from '@shared/services/api-service';
 
+import {
+	CAMPAIGN_MONITOR_SERVICE_BASE_URL,
+	CAMPAIGN_MONITOR_SERVICE_PREFERENCES,
+	CAMPAIGN_MONITOR_SERVICE_SEND,
+} from './campaign-monitor.consts';
+
 export class CampaignMonitorService {
+	public static async getPreferences(email: string): Promise<GetNewsletterPreferencesResponse> {
+		return await ApiService.getApi()
+			.get(
+				stringifyUrl({
+					url: `${CAMPAIGN_MONITOR_SERVICE_BASE_URL}/${CAMPAIGN_MONITOR_SERVICE_PREFERENCES}`,
+					query: {
+						email,
+					},
+				})
+			)
+			.json();
+	}
+
+	public static async setPreferences(preferences: SetNewsletterPreferencesBody): Promise<void> {
+		await ApiService.getApi()
+			.post(`${CAMPAIGN_MONITOR_SERVICE_BASE_URL}/${CAMPAIGN_MONITOR_SERVICE_PREFERENCES}`, {
+				body: JSON.stringify(preferences),
+			})
+			.json();
+	}
+
 	public static async send(json: EmailTemplate): Promise<void> {
-		await ApiService.getApi().post(`campaign-monitor/send`, { json }).json();
+		await ApiService.getApi()
+			.post(`${CAMPAIGN_MONITOR_SERVICE_SEND}/${CAMPAIGN_MONITOR_SERVICE_SEND}`, { json })
+			.json();
 	}
 }

--- a/src/modules/visitor-space/components/VisitorSpaceSearchPage/VisitorSpaceSearchPage.tsx
+++ b/src/modules/visitor-space/components/VisitorSpaceSearchPage/VisitorSpaceSearchPage.tsx
@@ -726,7 +726,7 @@ const VisitorSpaceSearchPage: FC = () => {
 
 		if (user?.groupName === GroupName.CP_ADMIN) {
 			// Don't show the temporary access label for CP_ADMIN's own visitor space
-			visitorSpaces = visitorSpaces.filter((space) => space.id !== user.visitorSpaceSlug);
+			visitorSpaces = visitorSpaces.filter((space) => space.slug !== user.visitorSpaceSlug);
 		}
 
 		if (isEmpty(visitorSpaces)) {

--- a/src/pages/account/mijn-profiel/index.tsx
+++ b/src/pages/account/mijn-profiel/index.tsx
@@ -89,9 +89,6 @@ const AccountMyProfile: NextPage<DefaultSeoInfo> = ({ url }) => {
 
 		try {
 			await CampaignMonitorService.setPreferences({
-				firstName: user.firstName,
-				lastName: user.lastName,
-				mail: user.email,
 				preferences: {
 					newsletter,
 				},
@@ -101,6 +98,8 @@ const AccountMyProfile: NextPage<DefaultSeoInfo> = ({ url }) => {
 			setIsFormSubmitting(false);
 		} catch (err) {
 			console.error(err);
+			console.log(err);
+
 			toastService.notify({
 				maxLines: 3,
 				title: tText('pages/account/mijn-profiel/index___error-communicatie'),


### PR DESCRIPTION
**TICKETS**
- Story: https://meemoo.atlassian.net/browse/ARC-1130
- Dev Task: https://meemoo.atlassian.net/browse/ARC-1190

**NOTES**
- Campaign monitor doesn't update the preferences directly in their db, that's why the preference checkbox is, in case you unchecked it, still checked after a refresh. 
- Try to test this with multiple accounts because campaign monitor has a limit of +- 4 post calls per user. After those, you'll receive an error message.