### PR TITLE
fix(arc-1187): fix navigation bar items margin

### DIFF
--- a/src/modules/navigation/components/Navigation/Navigation.module.scss
+++ b/src/modules/navigation/components/Navigation/Navigation.module.scss
@@ -215,11 +215,19 @@ $c-navigation-decoration: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDo
 		grid-column: 3/4;
 		justify-self: end;
 
-		// Ward: first child element is MaterialRequestCenterButton, which has a blade
-		// the other navigation items pop up through the blade if the following z-index is removed
 		ul {
-			li:first-child {
-				z-index: get-z-layer("filter");
+			grid-gap: 0;
+
+			li {
+				// Ward: first child element is MaterialRequestCenterButton, which has a blade
+				// the other navigation items pop up through the blade if the following z-index is removed
+				&:first-child {
+					z-index: get-z-layer("filter");
+				}
+
+				&:nth-child(2) {
+					padding: 0 1.5rem 0 0.5rem;
+				}
 			}
 		}
 	}
@@ -238,12 +246,7 @@ $c-navigation-decoration: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDo
 
 	display: grid;
 	grid-auto-flow: column;
-
-	li {
-		&:nth-child(2) {
-			padding: 0 1.5rem 0 0.5rem;
-		}
-	}
+	grid-gap: $c-navigation-item-spacing;
 
 	.c-navigation__list-flyout {
 		color: $black;


### PR DESCRIPTION
<img width="1637" alt="image" src="https://user-images.githubusercontent.com/113892598/233014042-40ec99e9-af2f-4bcd-ab5e-3c7e5abd5426.png">

Margin between 'Zoeken', 'Bezoek...', 'Over het archief' , ... was 0. 