### PR TITLE
fix(arc-1611): set title on 1 line if enough space in admin screens

### DIFF
--- a/src/modules/admin/layouts/AdminLayout/AdminLayout.module.scss
+++ b/src/modules/admin/layouts/AdminLayout/AdminLayout.module.scss
@@ -1,21 +1,19 @@
 @use "src/styles/abstracts" as *;
 
 .c-admin__header {
-	display: grid;
-	grid-auto-flow: column;
+	display: flex;
+	flex-direction: row;
 	padding-top: 6.4rem;
-	justify-content: space-between;
 	padding-bottom: $spacer-1xl;
 
-	@include respond-to(lg) {
-		grid-auto-flow: row;
-		grid-gap: $spacer-md;
+	@include respond-to(md) {
+		flex-direction: column;
 	}
 }
 
 .c-admin__page-title {
 	flex-grow: 1;
-	max-width: 50%;
+	max-width: 70%;
 
 	label {
 		overflow: hidden;
@@ -24,6 +22,10 @@
 }
 
 .c-admin__actions {
+	@include respond-to(md) {
+		margin-top: $spacer-md;
+	}
+
 	> :global(*) {
 		&:not(:last-child) {
 			margin-right: 0.8rem;


### PR DESCRIPTION
<img width="1024" alt="image" src="https://user-images.githubusercontent.com/113892598/234514380-b8dce540-06e5-474e-9e4f-18b0424aa2d2.png">
<img width="629" alt="image" src="https://user-images.githubusercontent.com/113892598/234514526-7d4c8ce2-e1d6-40c8-9275-63c8e06dee4c.png">

Ticket: https://meemoo.atlassian.net/browse/ARC-1611