### PR TITLE
fix(arc-1661): add tooltip to export metadata action

### DIFF
--- a/src/modules/ie-objects/const/index.tsx
+++ b/src/modules/ie-objects/const/index.tsx
@@ -238,6 +238,7 @@ export const MEDIA_ACTIONS = (
 							label: tText('modules/ie-objects/const/index___exporteer-metadata'),
 							id: MediaActions.Export,
 							ariaLabel: tText('modules/ie-objects/const/index___exporteer-metadata'),
+							tooltip: tText('modules/ie-objects/const/index___exporteer-metadata'),
 						},
 				  ]
 				: []) as ActionItem[]),


### PR DESCRIPTION
<img width="924" alt="image" src="https://user-images.githubusercontent.com/113892598/236155782-e1b341f6-6309-4e39-a20e-7b60e1641f9d.png">
Ticket: https://meemoo.atlassian.net/browse/ARC-1661