### PR TITLE
feat(MediaCard): always render labels

### DIFF
--- a/src/modules/shared/components/MediaCard/MediaCard.tsx
+++ b/src/modules/shared/components/MediaCard/MediaCard.tsx
@@ -378,17 +378,13 @@ const MediaCard: FC<MediaCardProps> = ({
 								<span>{renderDescription()}</span>
 							</div>
 						)}
-						{hasTempAccess && renderTempAccessPill()}
-						{showKeyUserLabel && renderKeyUserPill()}
-						{showLocallyAvailable && renderLocallyAvailableButtons()}
 					</>
 				) : (
-					<>
-						{wrapInLink(renderDescription())}
-						{showKeyUserLabel && renderKeyUserPill()}
-						{showLocallyAvailable && renderLocallyAvailableButtons()}
-					</>
+					<>{wrapInLink(renderDescription())}</>
 				)}
+				{hasTempAccess && renderTempAccessPill()}
+				{showKeyUserLabel && renderKeyUserPill()}
+				{showLocallyAvailable && renderLocallyAvailableButtons()}
 			</Card>
 			<Modal
 				title={tText(


### PR DESCRIPTION
Before: 
<img width="1912" alt="image" src="https://user-images.githubusercontent.com/77958553/236169771-485a5a36-6250-41f3-8161-e60197d1cf40.png">

After:
<img width="1912" alt="image" src="https://user-images.githubusercontent.com/77958553/236169813-a0ff9352-d825-4648-bac4-8e174ba0549d.png">
