### PR TITLE
fix(1655): add license filter to filter on objects with bzt license

### DIFF
--- a/src/modules/shared/types/ie-objects.ts
+++ b/src/modules/shared/types/ie-objects.ts
@@ -30,6 +30,7 @@ export enum IeObjectsSearchFilterField {
 	CAST = 'cast',
 	IDENTIFIER = 'identifier',
 	OBJECT_TYPE = 'objectType',
+	LICENSES = 'license', // Used to filter objects that are in a visitor space
 	CAPTION = 'caption', // Not available in database: https://docs.google.com/spreadsheets/d/1xAtHfkpDi4keSsBol7pw0cQAvCmg2hWRz8oxM6cP7zo/edit#gid=0
 	TRANSCRIPT = 'transcript', // Not available in database: https://docs.google.com/spreadsheets/d/1xAtHfkpDi4keSsBol7pw0cQAvCmg2hWRz8oxM6cP7zo/edit#gid=0
 	CATEGORIE = 'categorie', // Not available in database: https://docs.google.com/spreadsheets/d/1xAtHfkpDi4keSsBol7pw0cQAvCmg2hWRz8oxM6cP7zo/edit#gid=0

--- a/src/modules/visitor-space/components/VisitorSpaceSearchPage/VisitorSpaceSearchPage.tsx
+++ b/src/modules/visitor-space/components/VisitorSpaceSearchPage/VisitorSpaceSearchPage.tsx
@@ -208,7 +208,7 @@ const VisitorSpaceSearchPage: FC = () => {
 		isLoading: searchResultsLoading,
 		error: searchResultsError,
 	} = useGetIeObjects(
-		[mapMaintainerToElastic(query, activeVisitorSpace), ...mapFiltersToElastic(query)],
+		[...mapMaintainerToElastic(query, activeVisitorSpace), ...mapFiltersToElastic(query)],
 		query.page || 1,
 		VISITOR_SPACE_ITEM_COUNT,
 		activeSort,

--- a/src/modules/visitor-space/utils/elastic-filters/elastic-filters.ts
+++ b/src/modules/visitor-space/utils/elastic-filters/elastic-filters.ts
@@ -1,5 +1,6 @@
 import { compact } from 'lodash-es';
 
+import { IeObjectLicense } from '@ie-objects/types';
 import { SEARCH_QUERY_KEY } from '@shared/const';
 import {
 	IeObjectsSearchFilter,
@@ -19,17 +20,33 @@ import { mapAdvancedToElastic } from '../map-filters';
 export const mapMaintainerToElastic = (
 	query: VisitorSpaceQueryParams,
 	activeVisitorSpace: Visit | undefined
-): IeObjectsSearchFilter => {
+): IeObjectsSearchFilter[] => {
 	const maintainerId =
 		activeVisitorSpace?.spaceSlug === query?.[VisitorSpaceFilterId.Maintainer]
 			? activeVisitorSpace?.spaceMaintainerId
 			: '';
 
-	return {
-		field: IeObjectsSearchFilterField.MAINTAINER_ID,
-		operator: IeObjectsSearchOperator.IS,
-		value: maintainerId,
-	};
+	if (!maintainerId) {
+		return [];
+	}
+
+	return [
+		{
+			field: IeObjectsSearchFilterField.MAINTAINER_ID,
+			operator: IeObjectsSearchOperator.IS,
+			value: maintainerId,
+		},
+		// If a visitor space is selected, we only want to show objects that have a visitor space license
+		// https://meemoo.atlassian.net/browse/ARC-1655
+		{
+			field: IeObjectsSearchFilterField.LICENSES,
+			operator: IeObjectsSearchOperator.IS,
+			multiValue: [
+				IeObjectLicense.BEZOEKERTOOL_METADATA_ALL,
+				IeObjectLicense.BEZOEKERTOOL_CONTENT,
+			],
+		},
+	];
 };
 
 export const mapFiltersToElastic = (query: VisitorSpaceQueryParams): IeObjectsSearchFilter[] => [


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1655

Add a filter option to only receive search result objects that have specific licenses
So we can show only objects with the BEZOEKRERTOOL license on the search page if a user selected a visitor space

```json
{
  "size": 39,
  "from": 0,
  "query": {
    "bool": {
      "should": [
        {
          "bool": {
            "filter": [],
            "must": [
              {
                "term": {
                  "schema_maintainer.schema_identifier": "OR-7h1dk9t"
                }
              },
              {
                "terms": {
                  "schema_license": [
                    "BEZOEKERTOOL-METADATA-ALL",
                    "BEZOEKERTOOL-CONTENT"
                  ]
                }
              }
            ]
          }
        },
```

before:
![image](https://user-images.githubusercontent.com/1710840/236881042-72aebd32-93eb-497f-a9ca-144a95c2f2e4.png)

after:
![image](https://user-images.githubusercontent.com/1710840/236881061-b234b7cf-0050-441f-b56d-212daa228c1f.png)
