### PR TITLE
fix(detail): avoid related items call if maintainer id is undefined

### DIFF
--- a/src/modules/ie-objects/hooks/get-ie-objects-related.ts
+++ b/src/modules/ie-objects/hooks/get-ie-objects-related.ts
@@ -8,13 +8,24 @@ import { IeObject } from './../types';
 
 export const useGetIeObjectsRelated = (
 	id: string,
-	maintainerId: string,
-	meemooId: string,
+	maintainerId?: string,
+	meemooId?: string,
 	enabled = true
 ): UseQueryResult<IPagination<IeObject>> => {
 	return useQuery(
 		[QUERY_KEYS.getIeObjectsRelated, { id }],
-		() => IeObjectsService.getRelated(id, maintainerId, meemooId),
+		() => {
+			if (!maintainerId || !meemooId) {
+				return Promise.resolve({
+					items: [],
+					page: 1,
+					size: 0,
+					pages: 1,
+					total: 0,
+				} as IPagination<IeObject>);
+			}
+			IeObjectsService.getRelated(id, maintainerId, meemooId);
+		},
 		{
 			keepPreviousData: true,
 			enabled,

--- a/src/modules/ie-objects/services/ie-objects/ie-objects.service.ts
+++ b/src/modules/ie-objects/services/ie-objects/ie-objects.service.ts
@@ -126,9 +126,7 @@ export class IeObjectsService {
 			.get(
 				stringifyUrl({
 					url: `${IE_OBJECTS_SERVICE_BASE_URL}/${id}/${IO_OBJECTS_SERVICE_RELATED}/${meemooId}`,
-					query: {
-						...(!isEmpty(maintainerId) && { maintainerId }),
-					},
+					query: maintainerId ? { maintainerId } : {},
 				})
 			)
 			.json();

--- a/src/pages/zoeken/[slug]/[ie]/index.tsx
+++ b/src/pages/zoeken/[slug]/[ie]/index.tsx
@@ -253,8 +253,8 @@ const ObjectDetailPage: NextPage<ObjectDetailPageProps> = ({ title, url }) => {
 	// gerelateerd
 	const { data: relatedData } = useGetIeObjectsRelated(
 		router.query.ie as string,
-		isKiosk ? mediaInfo?.maintainerId ?? '' : '',
-		mediaInfo?.meemooIdentifier ?? '',
+		mediaInfo?.maintainerId,
+		mediaInfo?.meemooIdentifier,
 		!!mediaInfo
 	);
 


### PR DESCRIPTION
```
[Nest] 10708  - 09/05/2023, 14:23:48   ERROR [DataService] GraphQl query failed: [{"extensions":{"path":"$.selectionSet.object_ie.args.where.maintainer.schema_identifier._eq","code":"validation-failed"},"message":"unexpected null value for type \"String\""}] +978ms
[Nest] 10708  - 09/05/2023, 14:23:48   ERROR [DataService] Failed to get data from database +0ms
[Nest] 10708  - 09/05/2023, 14:23:48   ERROR [DataService] InternalServerErrorException: Internal Server Error Exception +1ms
[Nest] 10708  - 09/05/2023, 14:23:48   ERROR [ExceptionsHandler] Failed to get data from database, check the logs for more information.
```

![image](https://github.com/viaacode/hetarchief-client/assets/1710840/bad37cb5-8e25-407f-897f-4d1b178ab775)
