### PR TITLE
fix(arc-1178): fix date logic for approve visit and add unit tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -44,4 +44,7 @@ module.exports = {
 	},
 	testEnvironment: 'jsdom',
 	transformIgnorePatterns: ['/node_modules/(?!(ky))', '^.+\\.module\\.(css|sass|scss)$'],
+	globals: {
+		TZ: 'UTC',
+	},
 };

--- a/src/modules/shared/components/ApproveRequestBlade/ApproveRequestBlade.helpers.spec.ts
+++ b/src/modules/shared/components/ApproveRequestBlade/ApproveRequestBlade.helpers.spec.ts
@@ -1,0 +1,107 @@
+import {
+	getAccessToDate,
+	roundToNextQuarter,
+} from '@shared/components/ApproveRequestBlade/ApproveRequestBlade.helpers';
+
+describe('getAccessToDate', () => {
+	it('should return 18:00 for same day 09:00', () => {
+		expect(
+			getAccessToDate(new Date('2023-03-08T09:00:00'), new Date('2023-03-08T13:00:00'))
+		).toEqual(null);
+	});
+
+	it('should return 18:30 for same day 17:31', () => {
+		expect(
+			getAccessToDate(
+				new Date('2023-03-08T17:31:00'),
+				new Date('2023-03-08T13:00:00')
+			)?.toISOString()
+		).toEqual('2023-03-08T18:45:00.000Z');
+	});
+
+	it('should return 21:30 for same day 20:29', () => {
+		expect(
+			getAccessToDate(
+				new Date('2023-03-08T17:31:00'),
+				new Date('2023-03-08T13:00:00')
+			)?.toISOString()
+		).toEqual('2023-03-08T18:45:00.000Z');
+	});
+
+	it('should return null for next date 13:00', () => {
+		expect(
+			getAccessToDate(new Date('2023-03-08T17:31:00'), new Date('2023-03-09T13:00:00'))
+		).toEqual(null);
+	});
+
+	it('should return 00:45 for next date 00:10', () => {
+		expect(
+			getAccessToDate(
+				new Date('2023-03-08T23:40:00'),
+				new Date('2023-03-09T00:10:00')
+			)?.toISOString()
+		).toEqual('2023-03-09T00:45:00.000Z');
+	});
+
+	it('should return 18:00 for same day 00:10 and end date in the past', () => {
+		expect(
+			getAccessToDate(
+				new Date('2023-03-08T00:10:00'),
+				new Date('2023-03-07T00:10:00')
+			)?.toISOString()
+		).toEqual('2023-03-08T18:00:00.000Z');
+	});
+
+	it('should return 18:00 for same day 00:10 and end date in the past but same day', () => {
+		expect(
+			getAccessToDate(
+				new Date('2023-03-08T00:10:00'),
+				new Date('2023-03-08T00:09:00')
+			)?.toISOString()
+		).toEqual('2023-03-08T18:00:00.000Z');
+	});
+
+	it('should return null for 16:00 and end date 20:45', () => {
+		expect(
+			getAccessToDate(new Date('2023-03-08T16:00:00'), new Date('2023-03-08T20:45:00'))
+		).toEqual(null);
+	});
+
+	it('should return null for 16:00 and end date the next day', () => {
+		expect(
+			getAccessToDate(new Date('2023-03-08T16:00:00'), new Date('2023-03-09T00:45:00'))
+		).toEqual(null);
+	});
+});
+
+describe('roundToNextQuarter', () => {
+	it('should return 01:00 for 01:00', () => {
+		expect(roundToNextQuarter(new Date('2023-03-08T01:00:00'))?.toISOString()).toEqual(
+			'2023-03-08T01:00:00.000Z'
+		);
+	});
+
+	it('should return 01:00 for 00:40', () => {
+		expect(roundToNextQuarter(new Date('2023-03-08T00:40:00'))?.toISOString()).toEqual(
+			'2023-03-08T00:45:00.000Z'
+		);
+	});
+
+	it('should return 01:15 for 01:01', () => {
+		expect(roundToNextQuarter(new Date('2023-03-08T01:01:00'))?.toISOString()).toEqual(
+			'2023-03-08T01:15:00.000Z'
+		);
+	});
+
+	it('should return 01:15 for 01:15', () => {
+		expect(roundToNextQuarter(new Date('2023-03-08T01:15:00'))?.toISOString()).toEqual(
+			'2023-03-08T01:15:00.000Z'
+		);
+	});
+
+	it('should return 01:15 for 01:07', () => {
+		expect(roundToNextQuarter(new Date('2023-03-08T01:07:00'))?.toISOString()).toEqual(
+			'2023-03-08T01:15:00.000Z'
+		);
+	});
+});

--- a/src/modules/shared/components/ApproveRequestBlade/ApproveRequestBlade.helpers.ts
+++ b/src/modules/shared/components/ApproveRequestBlade/ApproveRequestBlade.helpers.ts
@@ -1,0 +1,68 @@
+import {
+	differenceInMinutes,
+	isAfter,
+	isBefore,
+	isSameDay,
+	roundToNearestMinutes,
+	subMinutes,
+} from 'date-fns';
+import addMinutes from 'date-fns/addMinutes';
+
+/**
+ * Determines if we should set the end date of an visit request when the user change the start date
+ *
+ * @param newAccessFromDate newly entered date for the accessFrom field modified by the user
+ * @param currentAccessToDate existing accessTo field value
+ * @return the date that the accessTo field should be changed to, or null if it shouldn't be changed
+ */
+export function getAccessToDate(newAccessFromDate: Date, currentAccessToDate: Date): Date | null {
+	const MINIMUM_VISIT_DURATION = 60; // minutes
+	const sixPm = new Date(
+		newAccessFromDate.getFullYear(),
+		newAccessFromDate.getMonth(),
+		newAccessFromDate.getDate(),
+		18,
+		0,
+		0
+	);
+
+	if (isAfter(currentAccessToDate, addMinutes(newAccessFromDate, MINIMUM_VISIT_DURATION))) {
+		// End date is valid for the newly selected start date
+		return null;
+	}
+
+	if (
+		isSameDay(newAccessFromDate, currentAccessToDate) ||
+		isBefore(currentAccessToDate, newAccessFromDate)
+	) {
+		// if accessTo date is the same day as the accessFrom or of the accessTo is earlier
+		// if the date is before 6pm - MINIMUM_VISIT_DURATION
+		if (isBefore(newAccessFromDate, subMinutes(sixPm, MINIMUM_VISIT_DURATION))) {
+			// before => update the accessTo to 6pm
+			return sixPm;
+		} else {
+			// after => update the accessTo to newAccessFrom + MINIMUM_VISIT_DURATION
+			return roundToNextQuarter(addMinutes(newAccessFromDate, MINIMUM_VISIT_DURATION));
+		}
+	} else {
+		// if accessTo is a later day than the accessFrom date
+		// differance between from and to dates is less than MINIMUM_VISIT_DURATION
+		if (differenceInMinutes(newAccessFromDate, currentAccessToDate) < MINIMUM_VISIT_DURATION) {
+			// less => update the accessTo to newAccessFrom + MINIMUM_VISIT_DURATION
+			return roundToNextQuarter(addMinutes(newAccessFromDate, MINIMUM_VISIT_DURATION));
+		} else {
+			// more => return null (do nothing to the accessTo field)
+			return null;
+		}
+	}
+}
+
+/**
+ * We're not using the build in date-fns roundToNearestMinutes function since it contains a bug
+ * https://github.com/date-fns/date-fns/issues/3129
+ * @param oldDate
+ */
+export function roundToNextQuarter(oldDate: Date): Date {
+	const minutes = Math.ceil(oldDate.getTime() / 1000 / 60 / 15) * 15;
+	return new Date(minutes * 60 * 1000);
+}

--- a/src/modules/shared/components/ApproveRequestBlade/ApproveRequestBlade.helpers.ts
+++ b/src/modules/shared/components/ApproveRequestBlade/ApproveRequestBlade.helpers.ts
@@ -1,12 +1,15 @@
-import {
-	differenceInMinutes,
-	isAfter,
-	isBefore,
-	isSameDay,
-	roundToNearestMinutes,
-	subMinutes,
-} from 'date-fns';
+import { differenceInMinutes, isAfter, isBefore, isSameDay, subMinutes } from 'date-fns';
 import addMinutes from 'date-fns/addMinutes';
+
+/**
+ * We're not using the build in date-fns roundToNearestMinutes function since it contains a bug
+ * https://github.com/date-fns/date-fns/issues/3129
+ * @param oldDate
+ */
+export const roundToNextQuarter = (oldDate: Date): Date => {
+	const minutes = Math.ceil(oldDate.getTime() / 1000 / 60 / 15) * 15;
+	return new Date(minutes * 60 * 1000);
+};
 
 /**
  * Determines if we should set the end date of an visit request when the user change the start date
@@ -15,7 +18,10 @@ import addMinutes from 'date-fns/addMinutes';
  * @param currentAccessToDate existing accessTo field value
  * @return the date that the accessTo field should be changed to, or null if it shouldn't be changed
  */
-export function getAccessToDate(newAccessFromDate: Date, currentAccessToDate: Date): Date | null {
+export const getAccessToDate = (
+	newAccessFromDate: Date,
+	currentAccessToDate: Date
+): Date | null => {
 	const MINIMUM_VISIT_DURATION = 60; // minutes
 	const sixPm = new Date(
 		newAccessFromDate.getFullYear(),
@@ -55,14 +61,4 @@ export function getAccessToDate(newAccessFromDate: Date, currentAccessToDate: Da
 			return null;
 		}
 	}
-}
-
-/**
- * We're not using the build in date-fns roundToNearestMinutes function since it contains a bug
- * https://github.com/date-fns/date-fns/issues/3129
- * @param oldDate
- */
-export function roundToNextQuarter(oldDate: Date): Date {
-	const minutes = Math.ceil(oldDate.getTime() / 1000 / 60 / 15) * 15;
-	return new Date(minutes * 60 * 1000);
-}
+};


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1178

Current implementation:
* select 18:00 as end date if from date is < 17:00
* otherwise take from date + 1 hour
* round to next quarter
* if end date is valid for a newly selected start date, do not modify the end date

main issues were:
* https://stackoverflow.com/questions/13359294/date-getday-javascript-returns-wrong-day
* https://github.com/date-fns/date-fns/issues/3129

![image](https://github.com/viaacode/hetarchief-client/assets/1710840/c0a5928f-e38c-443f-8447-2fdead4b06d4)
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/741b2430-5ee8-4160-a3f8-179cb10dd1d8)

![image](https://github.com/viaacode/hetarchief-client/assets/1710840/0fa08d92-f016-497a-9366-fab07fe190df)
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/4687b022-4ed0-4c3e-8a16-62add732bde9)
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/49611571-cfff-465c-bf3d-fd27ef6ff996)

