### PR TITLE
fix(arc-1214): align title with table + move notification back

### DIFF
--- a/src/styles/abstracts/_variables.scss
+++ b/src/styles/abstracts/_variables.scss
@@ -124,7 +124,7 @@ $breakpoints: (
 $z-layers: (
 	"modal": 9,
 	"blade": 8,
-	"alerts": 7,
+	"alerts": 2,
 	"filter-menu-mobile": 6,
 	"filter": 5,
 	"filter-overlay": 4,

--- a/src/styles/pages/admin/_alerts.scss
+++ b/src/styles/pages/admin/_alerts.scss
@@ -1,6 +1,11 @@
 @use "src/styles/abstracts" as *;
 
 .p-admin-alerts {
+	.c-admin__header {
+		padding-left: 0;
+		padding-right: 0;
+	}
+
 	.c-icon-picker .react-select__control {
 		border-radius: 0;
 		color: $black;


### PR DESCRIPTION
<img width="1406" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/dd6fb912-71f6-46e3-bbdb-8f43cdfc20b5">
<img width="1331" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/a41fc163-c67f-49af-8654-690da27a2bdf">
<img width="1397" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/389ec6fe-374b-429c-bf9c-4a46690b1d29">
<img width="1349" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/c587a735-df90-4f91-bac3-1aa3f562d74e">
<img width="1361" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/138799d2-51cb-4a8b-884b-a3e631a8bb80">
Ticket: https://meemoo.atlassian.net/browse/ARC-1214?focusedCommentId=39290