### PR TITLE
fix(arc-1522): fix redirect bug if item doesn't have kebabcasable title

### DIFF
--- a/src/modules/shared/components/MediaCardList/MediaCardList.tsx
+++ b/src/modules/shared/components/MediaCardList/MediaCardList.tsx
@@ -150,9 +150,9 @@ const MediaCardList: FC<MediaCardListProps> = ({
 
 	const tiles = items.map((item, i) => {
 		const link = stringifyUrl({
-			url: `/${ROUTE_PARTS.search}/${item.maintainerSlug}/${
-				item.schemaIdentifier
-			}/${kebabCase(item.name)}`,
+			url: `/${ROUTE_PARTS.search}/${item.maintainerSlug}/${item.schemaIdentifier}/${
+				kebabCase(item.name) || 'titel'
+			}`,
 			query: {
 				[QUERY_PARAM_KEY.HIGHLIGHTED_SEARCH_TERMS]: keywords,
 			},

--- a/src/pages/zoeken/[slug]/[ie]/index.tsx
+++ b/src/pages/zoeken/[slug]/[ie]/index.tsx
@@ -29,10 +29,11 @@ const IeObjectWithoutObjectNamePage: NextPage<MaintainerSearchPageProps> = () =>
 	// If the url is: /zoeken/:slug/:object-id => redirect to /zoeken/:slug/:object-id/:object-name
 	useEffect(() => {
 		if (ieObjectInfo) {
+			const objectTitleSlug = kebabCase(ieObjectInfo.name);
 			const searchUrl = stringifyUrl({
 				url: `/${ROUTE_PARTS.search}/${ieObjectInfo.maintainerSlug}/${
 					ieObjectInfo.schemaIdentifier
-				}/${kebabCase(ieObjectInfo.name)}`,
+				}/${objectTitleSlug || 'titel'}`,
 			});
 			router.replace(searchUrl, undefined, { shallow: true });
 		}


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1522

http://localhost:3200/zoeken/u-gent/37ed0eaf6e884d6ca4495029e2acdb3afcb13fec72a04eb08904dd275fef86c46e13c0e2bae048eebfbc6477d178ca84

zoeken/:maintainer/:ieObjectId should redirect to zoeken/:maintainer/:ieObjectId/title
but if the title isn't kebabcasable, then the redirect happens to zoeken/:maintainer/:ieObjectId
which causes an infinite loop

So this defaults the title to "titel" if kebabCase(object.name) is falsey

![image](https://github.com/viaacode/hetarchief-client/assets/1710840/432c2b93-1cb0-431a-9f76-403330beb045)


