### PR TITLE
fix(arc-1655): add filter on objects if the user received folder access

### DIFF
--- a/src/modules/shared/types/visit.ts
+++ b/src/modules/shared/types/visit.ts
@@ -18,6 +18,7 @@ export enum AccessType {
 
 export interface Visit {
 	accessibleFolderIds: string[];
+	accessibleObjectIds: string[];
 	createdAt: string;
 	endAt?: string;
 	id: string;

--- a/src/modules/visitor-space/components/SearchPage/SearchPage.tsx
+++ b/src/modules/visitor-space/components/SearchPage/SearchPage.tsx
@@ -202,7 +202,7 @@ const SearchPage: FC = () => {
 		setVisitorSpaces(sortedSpaces);
 
 		return sortedSpaces;
-	}, [user]);
+	}, [isAnonymousUser, isKioskUser, user]);
 
 	const {
 		data: searchResults,

--- a/src/modules/visitor-space/utils/elastic-filters/elastic-filters.ts
+++ b/src/modules/visitor-space/utils/elastic-filters/elastic-filters.ts
@@ -30,7 +30,16 @@ export const mapMaintainerToElastic = (
 		return [];
 	}
 
-	return [
+	const filterByObjectIds =
+		(activeVisitorSpace?.accessibleObjectIds?.length || 0) > 0
+			? {
+					field: IeObjectsSearchFilterField.IDENTIFIER,
+					operator: IeObjectsSearchOperator.IS,
+					multiValue: activeVisitorSpace?.accessibleObjectIds,
+			  }
+			: null;
+
+	return compact([
 		{
 			field: IeObjectsSearchFilterField.MAINTAINER_ID,
 			operator: IeObjectsSearchOperator.IS,
@@ -46,7 +55,10 @@ export const mapMaintainerToElastic = (
 				IeObjectLicense.BEZOEKERTOOL_CONTENT,
 			],
 		},
-	];
+		// Filter by object ids if the user received folder access to the visitor space
+		// https://meemoo.atlassian.net/browse/ARC-1655
+		filterByObjectIds,
+	]);
 };
 
 export const mapFiltersToElastic = (query: VisitorSpaceQueryParams): IeObjectsSearchFilter[] => {


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1655

user gets access to folder with 3 objects:
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/2178e6f1-0904-4458-93c5-025c001ef703)


before:
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/f8699e9c-8172-4f28-85ad-2340c226ad64)


after:
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/2fb1e5a6-6be4-414b-bdd2-a8cf98a65684)
