### PR TITLE
fix(arc-1740): show no access page when no access to object

### DIFF
--- a/src/pages/zoeken/[slug]/[ie]/[name]/index.tsx
+++ b/src/pages/zoeken/[slug]/[ie]/[name]/index.tsx
@@ -1433,6 +1433,18 @@ const ObjectDetailPage: NextPage<ObjectDetailPageProps> = ({ title, description,
 		}
 
 		if (isMediaInfoErrorNoAccess || isMediaInfoErrorNotFound) {
+			if (isNoAccessError) {
+				return (
+					<ErrorNoAccessToObject
+						visitorSpaceName={visitorSpace?.name as string}
+						visitorSpaceSlug={visitorSpace?.slug as string}
+						description={tHtml(
+							'pages/bezoekersruimte/visitor-space-slug/object-id/index___tot-het-materiaal-geen-toegang-dien-aanvraag-in'
+						)}
+					/>
+				);
+			}
+
 			if (isErrorSpaceNotFound) {
 				return <ErrorNotFound />;
 			}

--- a/src/pages/zoeken/[slug]/[ie]/index.tsx
+++ b/src/pages/zoeken/[slug]/[ie]/index.tsx
@@ -19,25 +19,25 @@ type MaintainerSearchPageProps = DefaultSeoInfo;
  */
 const IeObjectWithoutObjectNamePage: NextPage<MaintainerSearchPageProps> = () => {
 	const router = useRouter();
-	const { ie: objectId } = router.query;
+	const { ie: objectId, slug } = router.query;
 
-	const { data: ieObjectInfo } = useGetIeObjectsInfo(objectId as string, {
+	const { data: ieObjectInfo, isError } = useGetIeObjectsInfo(objectId as string, {
 		keepPreviousData: true,
 		enabled: !!objectId,
 	});
 
 	// If the url is: /zoeken/:slug/:object-id => redirect to /zoeken/:slug/:object-id/:object-name
 	useEffect(() => {
-		if (ieObjectInfo) {
-			const objectTitleSlug = kebabCase(ieObjectInfo.name);
+		if (ieObjectInfo || isError) {
+			const objectTitleSlug = kebabCase(ieObjectInfo?.name || '');
 			const searchUrl = stringifyUrl({
-				url: `/${ROUTE_PARTS.search}/${ieObjectInfo.maintainerSlug}/${
-					ieObjectInfo.schemaIdentifier
-				}/${objectTitleSlug || 'titel'}`,
+				url: `/${ROUTE_PARTS.search}/${ieObjectInfo?.maintainerSlug || slug}/${objectId}/${
+					objectTitleSlug || 'titel'
+				}`,
 			});
 			router.replace(searchUrl, undefined, { shallow: true });
 		}
-	}, [router, ieObjectInfo]);
+	}, [router, ieObjectInfo, isError]);
 
 	return <Loading owner="IeObjectWithoutObjectNamePage" fullscreen />;
 };


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1740

When you don't have access we cannot fetch the title of the object to redirect to the /slug/ieObjectId/title url, so the page keeps loading
if you go the the /title url manually, you still get a 404 instead of a no access (403)


before:
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/baa923a5-3cab-477d-bac2-345934fbd2f7)
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/c105cfe7-6ed9-4180-85cc-0976b652e31a)


after:
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/5c694825-926a-493c-8631-7684376e0476)

