### PR TITLE
fix(arc-1743): add padding to bottom of metadata

### DIFF
--- a/src/styles/pages/_object-detail.scss
+++ b/src/styles/pages/_object-detail.scss
@@ -230,6 +230,7 @@ $metadata-collapsed-width: 36vw;
 		margin-top: $spacer-xs;
 		padding: $spacer-md;
 		background-color: $platinum;
+		padding-bottom: 10rem;
 
 		@include respond-at("md") {
 			// Firefox and Safari render weirdly with: margin: 0 - $spacer-md;


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1743

before:
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/8d59e766-5c6a-4fe0-9425-91650091b406)

after:
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/53f6359d-9edc-4a0a-b2ec-7a58846b2f90)
