### PR TITLE
fix(arc-1777): hide consultable media filter in visitor space search

### DIFF
--- a/src/modules/visitor-space/const/index.tsx
+++ b/src/modules/visitor-space/const/index.tsx
@@ -130,7 +130,7 @@ export const VISITOR_SPACE_FILTERS = (
 		label: tText('modules/visitor-space/const/index___alles-wat-raadpleegbaar-is'),
 		form: ConsultableMediaFilterForm,
 		type: FilterMenuType.Checkbox,
-		isDisabled: () => !isKeyUser,
+		isDisabled: () => !isPublicCollection || !isKeyUser,
 	},
 	{
 		id: VisitorSpaceFilterId.ConsultableOnlyOnLocation,


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1777

before:
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/ac90de13-898a-43a0-85d6-1d6fdf0a4abf)

after:
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/894f400a-54cb-40c3-bdc0-bf1a87b1eecf)
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/c09add7f-cb62-4f93-aeb9-1e5707c6a67e)
