### PR TITLE
fix(arc-1783): reduce titles of account and admin pages on mobile

### DIFF
--- a/src/modules/account/layouts/AccountLayout/AccountLayout.module.scss
+++ b/src/modules/account/layouts/AccountLayout/AccountLayout.module.scss
@@ -9,4 +9,8 @@
 
 .c-account-admin__page-title {
 	flex-grow: 1;
+
+	@include respond-to("md") {
+		font-size: 2.8rem;
+	}
 }

--- a/src/modules/cp/layouts/CPAdminLayout/CPAdminLayout.module.scss
+++ b/src/modules/cp/layouts/CPAdminLayout/CPAdminLayout.module.scss
@@ -9,4 +9,8 @@
 
 .c-cp-admin__page-title {
 	flex-grow: 1;
+
+	@include respond-to("md") {
+		font-size: 2.8rem;
+	}
 }


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1783

before
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/f87c4d5e-1621-47f4-b5bf-4a269a2ac766)
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/0f33e492-ee1c-4760-9d28-9c39c72f110f)

after
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/320799c0-7049-4a5b-aa85-fc019540af7c)
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/5b7204ee-67c9-4996-9f18-df8aa576760c)
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/89ff9c9e-3e18-4435-8c63-158f09e126e6)
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/9b04f452-430e-4e23-ba1c-1d52c5e49e6c)
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/2f541a27-0389-447b-b684-24ab14559a23)
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/f4432c13-877d-48de-a72b-cd89ea6f4604)
