### PR TITLE
fix(arc-1806): add a white background + center inputs on mobile

### DIFF
--- a/src/styles/pages/newsletter/_newsletter.scss
+++ b/src/styles/pages/newsletter/_newsletter.scss
@@ -15,11 +15,14 @@ $page: "p-newsletter";
 		@include respond-to(lg) {
 			display: block;
 			margin-top: calc(50vw + 4.7rem);
+			padding: 0;
 		}
 	}
 
 	&__content {
 		grid-column: 2;
+		background-color: white;
+		padding: $spacer-lg;
 	}
 
 	&__header {


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1806

before:
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/82dc833f-2fc4-4882-b860-b72107ace07d)
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/3ef6e201-2d6d-4cca-a204-f61a9fe7c05d)


after:
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/5512e302-ce61-4e5e-9767-3483fcbfb78f)
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/13a81990-5536-40a6-8545-279abf25b4ee)
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/856ecc18-dc52-4b7b-841c-a5540bc4549e)
