### PR TITLE
fix(arc-1758): use same hover color for button in admin core

### DIFF
--- a/src/styles/admin-core/_content-pages-preview.scss
+++ b/src/styles/admin-core/_content-pages-preview.scss
@@ -273,7 +273,7 @@ $l-container-padding-xs: 2rem;
 		color: $white !important;
 
 		&:hover {
-			background-color: $black-light !important;
+			background-color: $shade !important;
 		}
 
 		&:active {


### PR DESCRIPTION
![image](https://github.com/viaacode/hetarchief-client/assets/113892598/514df258-62f9-4258-926e-7a96d90d1bbb)


Ticket: https://meemoo.atlassian.net/browse/ARC-1758