### PR TITLE
fix(arc-1832): remove top margin from materialrequestblade

### DIFF
--- a/src/modules/visitor-space/components/MaterialRequestBlade/MaterialRequestBlade.module.scss
+++ b/src/modules/visitor-space/components/MaterialRequestBlade/MaterialRequestBlade.module.scss
@@ -3,8 +3,6 @@
 $component: "c-request-material";
 
 .#{$component} {
-	margin-top: $c-navigation-height;
-
 	&__maintainer {
 		padding: $spacer-sm $spacer-lg;
 		background-color: $platinum;


### PR DESCRIPTION
<img width="1559" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/59a64023-2d1b-4d95-88a2-52f0dc1af550">


Ticket: https://meemoo.atlassian.net/browse/ARC-1832