### PR TITLE
fix(arc-1852): show html in tagsearchbarinfo

### DIFF
--- a/src/modules/shared/components/TagSearchBar/TagSearchBar.types.ts
+++ b/src/modules/shared/components/TagSearchBar/TagSearchBar.types.ts
@@ -11,7 +11,7 @@ export type TagSearchBarProps<IsMulti extends boolean = false> = DefaultComponen
 		inputState?: [string | undefined, Dispatch<SetStateAction<string | undefined>>];
 		light?: boolean;
 		hasDropdown?: boolean;
-		infoContent?: string;
+		infoContent?: string | ReactNode;
 		onClear?: () => void;
 		onCreate?: (newValue: string) => void;
 		onRemoveValue?: (removedValue: TagSearchBarValue<IsMulti>) => void;

--- a/src/modules/shared/components/TagSearchBar/TagSearchBarInfo/TagSearchBarInfo.types.ts
+++ b/src/modules/shared/components/TagSearchBar/TagSearchBarInfo/TagSearchBarInfo.types.ts
@@ -1,7 +1,9 @@
+import { ReactNode } from 'react';
+
 import { IconName } from '@shared/components/Icon';
 import { DefaultComponentProps } from '@shared/types';
 
 export interface TagSearchBarInfoProps extends DefaultComponentProps {
 	icon: IconName;
-	content: string;
+	content: string | ReactNode;
 }

--- a/src/modules/visitor-space/components/SearchPage/SearchPage.tsx
+++ b/src/modules/visitor-space/components/SearchPage/SearchPage.tsx
@@ -979,7 +979,7 @@ const SearchPage: FC = () => {
 											placeholder={tText(
 												'pages/bezoekersruimte/slug___zoek-op-trefwoord-jaartal-aanbieder'
 											)}
-											infoContent={tText(
+											infoContent={tHtml(
 												'modules/visitor-space/components/visitor-space-search-page/visitor-space-search-page___pages-bezoekersruimte-zoeken-zoek-info'
 											)}
 											size="lg"


### PR DESCRIPTION
<img width="864" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/440dd151-5478-47ff-a16f-f923f696289a">


Ticket: https://meemoo.atlassian.net/browse/ARC-1852