### PR TITLE
fix(arc-1840): add padding if many page digits

### DIFF
--- a/src/styles/components/_pagination.scss
+++ b/src/styles/components/_pagination.scss
@@ -43,6 +43,10 @@
 			color: $zinc;
 			cursor: default;
 		}
+
+		&--long {
+			padding: 2.5rem;
+		}
 	}
 
 	&__pages {


### PR DESCRIPTION
<img width="508" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/413d3dc7-a462-45c4-a60d-6e6cddc71d09">


Requires react-components PR: https://github.com/viaacode/react-components/pull/96
Ticket: https://meemoo.atlassian.net/browse/ARC-1840