### PR TITLE
fix(arc-1711): if mobile show tooltip on rightside

### DIFF
--- a/src/modules/shared/components/Pill/Pill.tsx
+++ b/src/modules/shared/components/Pill/Pill.tsx
@@ -2,19 +2,25 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@meemoo/react-component
 import clsx from 'clsx';
 import { FC, ReactElement } from 'react';
 
+import { useWindowSizeContext } from '@shared/hooks/use-window-size-context';
+import { Breakpoints } from '@shared/types';
+
 import { Icon } from '..';
 
 import styles from './Pill.module.scss';
 import { PillProps } from './Pill.types';
 
 const Pill: FC<PillProps> = ({ className, icon, label, isExpanded }: PillProps): ReactElement => {
+	const windowSize = useWindowSizeContext();
+	const isMobile = !!(windowSize.width && windowSize.width < Breakpoints.md);
+
 	const rootCls = clsx(className, styles['c-pill'], {
 		[styles['c-pill--expanded']]: isExpanded,
 	});
 
 	const renderTooltipPill = (): ReactElement => (
 		<span className={rootCls}>
-			<Tooltip position="top">
+			<Tooltip position={isMobile ? 'right' : 'top'}>
 				<TooltipTrigger>
 					<Icon name={icon} />
 				</TooltipTrigger>


### PR DESCRIPTION
<img width="427" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/40726726-61b2-4cd6-8f9d-4761bb47e6a5">


Ticket: https://meemoo.atlassian.net/browse/ARC-1711