### PR TITLE
fix(arc-1749): add padding to match other admin pages

### DIFF
--- a/src/styles/admin-core/_content-pages.scss
+++ b/src/styles/admin-core/_content-pages.scss
@@ -46,7 +46,7 @@ $content-page-sidebar-blok-dropdown-height: 7rem;
 	.p-admin-content {
 		.c-filter-table thead th,
 		.c-filter-table tbody td {
-			padding: $spacer-sm $spacer-xs;
+			padding: $spacer-md;
 			line-height: $line-height-lg;
 		}
 
@@ -60,7 +60,7 @@ $content-page-sidebar-blok-dropdown-height: 7rem;
 	.p-admin-content-page-labels__edit {
 		[class*="c-box"] {
 			background-color: transparent;
-			padding: 0 1rem;
+			padding: $spacer-md;
 		}
 	}
 
@@ -81,6 +81,12 @@ $content-page-sidebar-blok-dropdown-height: 7rem;
 	.p-admin-content-page-labels__edit,
 	.p-admin-content__create,
 	.p-admin-content__edit {
+		.c-table thead th,
+		.c-table tbody td {
+			padding: $spacer-md;
+			line-height: $line-height-lg;
+		}
+
 		.o-container--medium {
 			max-width: 100%;
 			padding: $spacer-md;


### PR DESCRIPTION
<img width="1122" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/4deffdd1-d7a0-491d-a46a-c603ff8b8028">
<img width="1124" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/c8a2d8e2-6d56-4af0-b4b7-350788fb3dff">
<img width="1190" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/69d9684a-2006-4815-825c-4799f8e88b8d">
<img width="1028" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/aa6015d9-bb09-4e48-8be4-0caeb94b8207">



Ticket: https://meemoo.atlassian.net/browse/ARC-1749