### PR TITLE
fix(arc-1785): hide outline on focus visible iPad

### DIFF
--- a/src/modules/visitor-space/components/AddToFolderBlade/AddToFolderBlade.module.scss
+++ b/src/modules/visitor-space/components/AddToFolderBlade/AddToFolderBlade.module.scss
@@ -46,6 +46,13 @@ $add-to-collection-checkbox-padding: $spacer-xs + $spacer-xxs;
 			align-items: center;
 			cursor: pointer;
 
+			&:active,
+			&:focus,
+			&:focus-visible {
+				outline: none;
+				border: none;
+			}
+
 			&__checkbox {
 				flex-shrink: 0;
 


### PR DESCRIPTION
<img width="1030" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/769997cd-a83f-44fe-9ee1-db7c31a912ae">


Ticket: https://meemoo.atlassian.net/browse/ARC-1785