### PR TITLE
fix(arc-1838): align maintainer logos left instead of center

### DIFF
--- a/src/styles/admin-core/content-blocks/_maintainers-grid.scss
+++ b/src/styles/admin-core/content-blocks/_maintainers-grid.scss
@@ -41,10 +41,6 @@ $component: "c-block-maintainers-grid";
 				margin-top: $spacer-xs;
 			}
 		}
-
-		ul {
-			justify-content: space-around;
-		}
 	}
 
 	&__image {


### PR DESCRIPTION
<img width="598" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/e404c517-0496-436d-aab7-543284a0c4b9">


Ticket: https://meemoo.atlassian.net/browse/ARC-1838