### PR TITLE
fix(arc-1839): fix mobile view of cards without description

### DIFF
--- a/src/styles/admin-core/content-blocks/_cards-without-description.scss
+++ b/src/styles/admin-core/content-blocks/_cards-without-description.scss
@@ -4,6 +4,7 @@
 
 $component: "c-block-cards-without-description";
 $img-size: 15.2rem;
+$img-size-mobile: 10.2rem;
 
 .#{$component} {
 	width: 100%;
@@ -33,6 +34,10 @@ $img-size: 15.2rem;
 		color: $white;
 		display: grid;
 		grid-template-columns: repeat(2, 7.6rem) 1fr;
+
+		@include respond-to("sm") {
+			height: $img-size-mobile;
+		}
 	}
 
 	a {
@@ -47,6 +52,11 @@ $img-size: 15.2rem;
 		padding: 0 $spacer-md 0 (math.div($img-size, 2) + $spacer-md);
 		font-weight: $font-weight-bold;
 		font-size: 2rem;
+
+		@include respond-to("sm") {
+			grid-column: 1/4;
+			margin-left: 5rem;
+		}
 	}
 
 	&__image {
@@ -64,6 +74,11 @@ $img-size: 15.2rem;
 
 		&--round {
 			border-radius: $img-size;
+		}
+
+		@include respond-to("sm") {
+			width: $img-size-mobile;
+			height: $img-size-mobile;
 		}
 	}
 }


### PR DESCRIPTION
<img width="466" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/b745d159-015e-4a7b-87e8-ddf769cb4563">


Ticket: https://meemoo.atlassian.net/browse/ARC-1839