### PR TITLE
fix(arc-1851): fix font family dropdown labels

### DIFF
--- a/src/styles/components/_dropdown.scss
+++ b/src/styles/components/_dropdown.scss
@@ -158,6 +158,7 @@
 		display: flex;
 		align-items: center;
 		gap: $spacer-xs;
+		font-family: $font-family-primary;
 	}
 }
 


### PR DESCRIPTION
<img width="797" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/1d50569e-bfd0-4b2c-b6f6-289fb3039bb3">


Ticket: https://meemoo.atlassian.net/browse/ARC-1851