### PR TITLE
fix(arc-1122): hide main image of contentpage

### DIFF
--- a/src/styles/pages/admin/_rewrites.scss
+++ b/src/styles/pages/admin/_rewrites.scss
@@ -39,13 +39,6 @@ table[class*="c-table--styled"] {
 		border-bottom: $c-table-border;
 		border-top: $c-table-border;
 
-		// ARC-1122: hide first child (image)
-		tr {
-			&:first-child {
-				display: none;
-			}
-		}
-
 		@include respond-at("lg") {
 			box-shadow: $shadow-24-black-08;
 		}
@@ -63,16 +56,22 @@ table[class*="c-table--styled"] {
 	}
 }
 
-// ARC-1122: hide first child (image)
-.c-content-edit-form {
-	.o-grid {
-		div {
+.c-table_detail-page {
+	tbody {
+		// ARC-1122: hide first child (image)
+		tr {
 			&:first-child {
-				div {
-					&:first-child {
-						display: none;
-					}
-				}
+				display: none;
+			}
+		}
+	}
+}
+
+.c-content-edit-form {
+	div {
+		div:first-child {
+			div:first-child {
+				display: none;
 			}
 		}
 	}

--- a/src/styles/pages/admin/_rewrites.scss
+++ b/src/styles/pages/admin/_rewrites.scss
@@ -70,6 +70,7 @@ table[class*="c-table--styled"] {
 .c-content-edit-form {
 	div {
 		div:first-child {
+			// ARC-1122: hide first child (image)
 			div:first-child {
 				display: none;
 			}

--- a/src/styles/pages/admin/_rewrites.scss
+++ b/src/styles/pages/admin/_rewrites.scss
@@ -39,6 +39,13 @@ table[class*="c-table--styled"] {
 		border-bottom: $c-table-border;
 		border-top: $c-table-border;
 
+		// ARC-1122: hide first child (image)
+		tr {
+			&:first-child {
+				display: none;
+			}
+		}
+
 		@include respond-at("lg") {
 			box-shadow: $shadow-24-black-08;
 		}
@@ -53,6 +60,21 @@ table[class*="c-table--styled"] {
 
 	tr {
 		border-bottom: $c-table-border;
+	}
+}
+
+// ARC-1122: hide first child (image)
+.c-content-edit-form {
+	.o-grid {
+		div {
+			&:first-child {
+				div {
+					&:first-child {
+						display: none;
+					}
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
<img width="857" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/1d669863-7be8-4801-b574-a0f9039aaf46">
<img width="848" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/42975f6d-4649-4e16-a783-b81019714592">
<img width="855" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/6541bfe5-5b3c-4d4e-a24e-60ba06e8d7c4">


Ticket: https://meemoo.atlassian.net/browse/ARC-1122