### PR TITLE
fix(arc-1827): long string continues on new line in search

### DIFF
--- a/src/styles/components/_tags-input.scss
+++ b/src/styles/components/_tags-input.scss
@@ -26,6 +26,7 @@
 			font-family: inherit;
 			line-height: inherit;
 			color: inherit;
+			word-break: break-word;
 
 			@include respond-at(md) {
 				margin: $spacer-xxs $spacer-sm $spacer-xxs 0;


### PR DESCRIPTION
<img width="980" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/df12ae56-a072-4b54-a968-edd234f92f45">


Ticket: https://meemoo.atlassian.net/browse/ARC-1827