### PR TITLE
fix(arc-1854): add margin to show outline button link

### DIFF
--- a/src/styles/admin-core/_content-pages-preview.scss
+++ b/src/styles/admin-core/_content-pages-preview.scss
@@ -264,6 +264,7 @@ $l-container-padding-xs: 2rem;
 		&:focus,
 		.focus-visible:focus:not(:focus-visible) {
 			outline: 2px solid $teal !important;
+			margin: 4px 0;
 		}
 	}
 

--- a/src/styles/admin-core/_content-pages-preview.scss
+++ b/src/styles/admin-core/_content-pages-preview.scss
@@ -248,6 +248,7 @@ $l-container-padding-xs: 2rem;
 		border-color: transparent !important;
 		color: $teal !important;
 		text-decoration: underline;
+		margin: 4px 0;
 
 		&:hover {
 			background-color: transparent !important;
@@ -264,7 +265,6 @@ $l-container-padding-xs: 2rem;
 		&:focus,
 		.focus-visible:focus:not(:focus-visible) {
 			outline: 2px solid $teal !important;
-			margin: 4px 0;
 		}
 	}
 


### PR DESCRIPTION
Before: 
<img width="1049" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/62deae85-6f96-443e-9247-301a185be615">


After:
<img width="943" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/c6a9f9ad-9b3a-4593-9cac-463e9dde9749">


Ticket: https://meemoo.atlassian.net/browse/ARC-1854