### PR TITLE
feat(arc-1878): use organization instead of visitor space to check slugs

### DIFF
--- a/src/modules/shared/services/organisation-service/organisation.service.ts
+++ b/src/modules/shared/services/organisation-service/organisation.service.ts
@@ -1,0 +1,14 @@
+import { ApiService } from '@shared/services/api-service';
+import { Organisation } from '@shared/services/organisation-service/organisation.types';
+
+export class OrganisationService {
+	public static async getBySlug(
+		slug: string | null,
+		ignoreAuthError: boolean
+	): Promise<Organisation | null> {
+		if (!slug) {
+			return null;
+		}
+		return await ApiService.getApi(ignoreAuthError).get(`organisations/${slug}`).json();
+	}
+}

--- a/src/modules/shared/services/organisation-service/organisation.types.ts
+++ b/src/modules/shared/services/organisation-service/organisation.types.ts
@@ -1,0 +1,34 @@
+import { IeObjectSector } from '@ie-objects/types';
+
+export interface Organisation {
+	schemaIdentifier: string;
+	contactPoint: OrganisationContactPoint[];
+	description: string;
+	logo: {
+		iri: string;
+	};
+	slug: string | null;
+	primarySite: OrganisationPrimarySite;
+	schemaName: string;
+	createdAt: string;
+	updatedAt: string;
+	sector: IeObjectSector | null;
+	formUrl: string | null;
+}
+
+export interface OrganisationContactPoint {
+	contactType: string;
+	email: string;
+}
+
+export interface OrganisationPrimarySite {
+	address: OrganisationPrimarySiteAddress;
+}
+
+export interface OrganisationPrimarySiteAddress {
+	locality: string;
+	postal_code: string;
+	street: string;
+	telephone: string;
+	post_office_box_number: string;
+}

--- a/src/modules/visitor-space/hooks/get-organisation-by-slug.ts
+++ b/src/modules/visitor-space/hooks/get-organisation-by-slug.ts
@@ -1,0 +1,17 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+
+import { QUERY_KEYS } from '@shared/const/query-keys';
+import { OrganisationService } from '@shared/services/organisation-service/organisation.service';
+import { Organisation } from '@shared/services/organisation-service/organisation.types';
+
+export function useGetOrganisationBySlug(
+	slug: string | null,
+	ignoreAuthError = false,
+	options: { enabled: boolean } = { enabled: true }
+): UseQueryResult<Organisation | null> {
+	return useQuery(
+		[QUERY_KEYS.getIeObjectsInfo, { slug }],
+		() => OrganisationService.getBySlug(slug as string, ignoreAuthError),
+		options
+	);
+}

--- a/src/pages/zoeken/[slug]/index.tsx
+++ b/src/pages/zoeken/[slug]/index.tsx
@@ -10,7 +10,7 @@ import { Loading } from '@shared/components';
 import { ROUTE_PARTS } from '@shared/const';
 import { getDefaultServerSideProps } from '@shared/helpers/get-default-server-side-props';
 import { DefaultSeoInfo } from '@shared/types/seo';
-import { useGetVisitorSpace } from '@visitor-space/hooks/get-visitor-space';
+import { useGetOrganisationBySlug } from '@visitor-space/hooks/get-organisation-by-slug';
 import { FILTER_LABEL_VALUE_DELIMITER, VisitorSpaceFilterId } from '@visitor-space/types';
 
 type MaintainerSearchPageProps = DefaultSeoInfo;
@@ -18,7 +18,7 @@ type MaintainerSearchPageProps = DefaultSeoInfo;
 const MaintainerSearchPage: NextPage<MaintainerSearchPageProps> = () => {
 	const router = useRouter();
 	const { slug: slugOrObjectId } = router.query;
-	const { data: visitorSpaceInfo } = useGetVisitorSpace(
+	const { data: organisation } = useGetOrganisationBySlug(
 		(slugOrObjectId || null) as string | null,
 		true,
 		{
@@ -32,16 +32,16 @@ const MaintainerSearchPage: NextPage<MaintainerSearchPageProps> = () => {
 
 	// If url is: /zoeken/slug/:object-id => redirect to /zoeken/:slug/:object-id/:object-name
 	useEffect(() => {
-		if (visitorSpaceInfo) {
+		if (organisation) {
 			const searchUrl = stringifyUrl({
 				url: `/${ROUTE_PARTS.search}`,
 				query: {
-					[VisitorSpaceFilterId.Maintainers]: `${visitorSpaceInfo.maintainerId}${FILTER_LABEL_VALUE_DELIMITER}${visitorSpaceInfo.name}`,
+					[VisitorSpaceFilterId.Maintainers]: `${organisation.schemaIdentifier}${FILTER_LABEL_VALUE_DELIMITER}${organisation.schemaName}`,
 				},
 			});
 			router.replace(searchUrl, undefined, { shallow: true });
 		}
-	}, [router, visitorSpaceInfo]);
+	}, [router, organisation]);
 
 	// If the url is: /zoeken/:object-id => redirect to /zoeken/:slug/:object-id/:object-name
 	useEffect(() => {


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1878

requires backend PR: https://github.com/viaacode/hetarchief-proxy/pull/451

redirects 
http://localhost:3200/zoeken/rosas
➡️ 
http://localhost:3200/zoeken?aanbieders=OR-cc0ts82---Rosas&format=all&orderDirection=desc&orderProp=relevance&page=1

even if the visitor space does not exist


![image](https://github.com/viaacode/hetarchief-client/assets/1710840/0a6efe66-34e3-477a-8c0a-7784a780e0df)
