### PR TITLE
fix(arc-1889): make content page columns have less padding

### DIFF
--- a/src/styles/admin-core/_content-pages.scss
+++ b/src/styles/admin-core/_content-pages.scss
@@ -46,8 +46,14 @@ $content-page-sidebar-blok-dropdown-height: 7rem;
 	.p-admin-content {
 		.c-filter-table thead th,
 		.c-filter-table tbody td {
-			padding: $spacer-md;
+			// Keep the columns narrow, so they fit on a 1440px wide screen
+			// https://meemoo.atlassian.net/browse/ARC-1889
+			padding: $spacer-md 0.5rem;
 			line-height: $line-height-lg;
+
+			&:first-child {
+				padding-left: $spacer-md;
+			}
 		}
 
 		.c-button-toolbar button[class*="c-button"] {


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1889

so the table fits on a 1440px wide screen

before:
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/140ff537-36df-4316-af7b-a78f360cd445)

after:
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/17508b72-2f9a-4df4-8a66-2d57da8ce31d)
