### PR TITLE
fix(arc-1099): set scrollable height based on 100vh instead of percent

### DIFF
--- a/src/styles/pages/_object-detail.scss
+++ b/src/styles/pages/_object-detail.scss
@@ -225,8 +225,12 @@ $breakpoint-md: map.get($breakpoints, "md");
 
 		.ScrollbarsCustom {
 			width: 100% !important;
-			height: 500px !important;
-			max-height: 100% !important;
+			height: calc(100vh - 10rem - 5.4rem - 8rem) !important;
+			max-height: 500px !important;
+
+			@include respond-to("md") {
+				height: calc(100vh - 10rem - 5.4rem - 8rem - 6.5rem) !important;
+			}
 
 			.ScrollbarsCustom-TrackY > .ScrollbarsCustom-Thumb {
 				background-color: $neutral !important;


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1099

example: https://hetarchief.be/zoeken/vrt/44acf5784e854be0bfdc9cd08862065b5af8ab8b4cff444ba9b4d106ab44bb15c86820e53c2b443d8799dbf6f992b8a9/film?tab=metadata

before:
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/46a7eaa8-d26b-43fd-a6a7-86a8da2c8c96)


after:
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/81ff81f9-ae76-4cf4-bf07-01394af25e01)
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/c6d03df1-c09c-4f0a-ae66-a4af9bd52a46)
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/54383fef-21f4-48e3-ab38-6ced8ec93bfc)
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/2a9056ff-dd76-4f66-b6e0-118a3ad5a523)
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/0f34ae2e-faed-4541-a0fa-a7157a6a0e42)
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/c583575e-9035-4835-b8c8-862c9ba761f6)
