### PR TITLE
fix(arc-1961): reduce minwidth in sharefolderblade

### DIFF
--- a/src/modules/shared/components/ShareFolderBlade/ShareFolderBlade.module.scss
+++ b/src/modules/shared/components/ShareFolderBlade/ShareFolderBlade.module.scss
@@ -12,7 +12,7 @@ $component: "c-share-folder-blade";
 	&__content {
 		color: $black;
 		padding: 0 $spacer-lg;
-		min-width: 40rem;
+		min-width: 26rem;
 
 		&-label {
 			font-weight: bold;


### PR DESCRIPTION
<img width="276" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/fc50d4cc-bfee-4f41-97c7-e277d0b1bf3c">

Ticket: https://meemoo.atlassian.net/browse/ARC-1961