### PR TITLE
fix(arc-1935): increase metadata logo height

### DIFF
--- a/src/styles/pages/_object-detail.scss
+++ b/src/styles/pages/_object-detail.scss
@@ -305,7 +305,7 @@ $breakpoint-md: map.get($breakpoints, "md");
 					grid-row: 1/3;
 					grid-column: 2;
 					width: 100%;
-					height: 3.2rem;
+					height: 5rem;
 					overflow: hidden;
 					position: relative;
 


### PR DESCRIPTION
<img width="352" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/f963a97a-9d81-4f7c-a7ee-3151c0c6ec7f">

Ticket: https://meemoo.atlassian.net/browse/ARC-1935