### PR TITLE
fix(arc-1984): center align imgs in grid

### DIFF
--- a/src/styles/admin-core/content-blocks/_content-block-image-grid.scss
+++ b/src/styles/admin-core/content-blocks/_content-block-image-grid.scss
@@ -6,7 +6,7 @@ $component: "c-content-block__image-grid";
 	.c-block-grid {
 		column-gap: 3.4rem;
 		row-gap: 8rem;
-		justify-content: space-between;
+		justify-content: center;
 
 		&__item {
 			margin: 0 !important;


### PR DESCRIPTION
<img width="1000" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/f93a8fe7-e3dc-4ee1-a7cd-6d1a989d881d">


Ticket: https://meemoo.atlassian.net/browse/ARC-1984