### PR TITLE
fix(arc-1956): show delete tooltip text to align actions

### DIFF
--- a/src/pages/account/mijn-mappen/[folderSlug]/index.tsx
+++ b/src/pages/account/mijn-mappen/[folderSlug]/index.tsx
@@ -292,7 +292,9 @@ const AccountMyFolders: NextPage<DefaultSeoInfo> = ({ url }) => {
 											? tText(
 													'pages/account/mijn-mappen/folder-slug/index___map-beperkte-toegang-niet-verwijderen'
 											  )
-											: undefined
+											: tText(
+													'pages/account/mijn-mappen/folder-slug/index___map-verwijderen'
+											  )
 									}
 								/>
 							),


### PR DESCRIPTION
<img width="875" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/483937ef-0703-4574-a7d9-d965073be9df">


Ticket: https://meemoo.atlassian.net/browse/ARC-1956