### PR TITLE
fix(arc-1941): fix right arrow of tooltip

### DIFF
--- a/src/styles/components/_tooltip.scss
+++ b/src/styles/components/_tooltip.scss
@@ -29,6 +29,12 @@ $component: "c-tooltip-component";
 		}
 	}
 
+	&[data-popper-placement^="left"] > .c-tooltip-component__arrow {
+		right: 6px !important;
+		transform: translate(0, -6px) !important;
+		clip: unset !important;
+	}
+
 	&[data-popper-placement^="right"] > .c-tooltip-component__arrow {
 		left: -6px !important;
 		transform: translate(0, -6px) !important;


### PR DESCRIPTION
<img width="432" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/76ac7ff1-5ba0-4924-8d5d-aee7640b5a60">


Ticket: https://meemoo.atlassian.net/browse/ARC-1941