### PR TITLE
feat(arc-1936): make url clickable metadata identifier

### DIFF
--- a/src/modules/shared/components/MetaDataFieldWithHighlightingAndMaxLength/MetaDataFieldWithHighlightingAndMaxLength.tsx
+++ b/src/modules/shared/components/MetaDataFieldWithHighlightingAndMaxLength/MetaDataFieldWithHighlightingAndMaxLength.tsx
@@ -44,9 +44,24 @@ const MetaDataFieldWithHighlightingAndMaxLength: FC<
 			// Split text on new lines and highlight each part separately + put each part in its own paragraph to show new lines
 			return parsedFieldData
 				.split(/(\\\\r|\\r)?\\\\n|\\n/)
-				.map((fieldTextPart, fieldTextPartIndex) => (
-					<span key={title + '-' + fieldTextPartIndex}>{highlighted(fieldTextPart)}</span>
-				));
+				.map((fieldTextPart, fieldTextPartIndex) => {
+					// ARC-1936: if url make it clickable
+					if (data.startsWith('https://') || data.startsWith('http://')) {
+						return (
+							<span key={title + '-' + fieldTextPartIndex}>
+								<a href={fieldTextPart} target="_blank" rel="noreferrer">
+									{highlighted(fieldTextPart)}
+								</a>
+							</span>
+						);
+					} else {
+						return (
+							<span key={title + '-' + fieldTextPartIndex}>
+								{highlighted(fieldTextPart)}
+							</span>
+						);
+					}
+				});
 		} else {
 			return parsedFieldData;
 		}


### PR DESCRIPTION
<img width="523" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/55b88615-3325-4a25-805a-92b8f53bf106">


Ticket: https://meemoo.atlassian.net/browse/ARC-1936