### PR TITLE
feat(arc-1943): sort filter options letters first then digits then rest

### DIFF
--- a/src/modules/visitor-space/components/GenreFilterForm/GenreFilterForm.tsx
+++ b/src/modules/visitor-space/components/GenreFilterForm/GenreFilterForm.tsx
@@ -1,7 +1,7 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import { CheckboxList } from '@meemoo/react-components';
 import clsx from 'clsx';
-import { compact, noop, sortBy, without } from 'lodash-es';
+import { compact, noop, without } from 'lodash-es';
 import { FC, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useSelector } from 'react-redux';
@@ -13,6 +13,7 @@ import { selectIeObjectsFilterOptions } from '@shared/store/ie-objects/ie-object
 import { IeObjectsSearchFilterField } from '@shared/types';
 import { visitorSpaceLabelKeys } from '@visitor-space/const';
 import { VisitorSpaceFilterId } from '@visitor-space/types';
+import { sortFilterOptions } from '@visitor-space/utils/sort-filter-options';
 
 import {
 	GENRE_FILTER_FORM_QUERY_PARAM_CONFIG,
@@ -50,16 +51,13 @@ const GenreFilterForm: FC<GenreFilterFormProps> = ({ children, className }) => {
 	// Make sure applied values are sorted at the top of the list
 	// Options selected by the user should remain in their alphabetical order until the filter is applied
 	// https://meemoo.atlassian.net/browse/ARC-1882
-	const checkboxOptions = sortBy(
+	const checkboxOptions = sortFilterOptions(
 		filterOptions.map((filterOption) => ({
 			label: filterOption,
 			value: filterOption,
 			checked: selectedGenres.includes(filterOption),
 		})),
-		(option) =>
-			(appliedSelectedGenres.includes(option.value) ? '0' : '1') +
-			'___' +
-			option.label.toLowerCase()
+		appliedSelectedGenres
 	);
 
 	// Effects

--- a/src/modules/visitor-space/components/GenreSelect/GenreSelect.tsx
+++ b/src/modules/visitor-space/components/GenreSelect/GenreSelect.tsx
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux';
 import useTranslation from '@shared/hooks/use-translation/use-translation';
 import { selectIeObjectsFilterOptions } from '@shared/store/ie-objects/ie-objects.select';
 import { IeObjectsSearchFilterField } from '@shared/types';
+import { sortFilterOptions } from '@visitor-space/utils/sort-filter-options';
 
 const GenreSelect: FC<ReactSelectProps> = (props) => {
 	const { tText } = useTranslation();
@@ -12,11 +13,13 @@ const GenreSelect: FC<ReactSelectProps> = (props) => {
 		IeObjectsSearchFilterField.GENRE
 	];
 
-	const options = (filterOptions || []).map((filterOption) => ({
-		// label: `${bucket.key} (${bucket.doc_count})`, // Disabled due to non-representative scale of results
-		label: filterOption,
-		value: filterOption,
-	}));
+	const options = sortFilterOptions(
+		(filterOptions || []).map((filterOption) => ({
+			label: filterOption,
+			value: filterOption,
+		})),
+		[]
+	);
 
 	// Bind to defaultProps to access externally
 	GenreSelect.defaultProps = { options };

--- a/src/modules/visitor-space/components/LanguageFilterForm/LanguageFilterForm.tsx
+++ b/src/modules/visitor-space/components/LanguageFilterForm/LanguageFilterForm.tsx
@@ -1,7 +1,7 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import { CheckboxList } from '@meemoo/react-components';
 import clsx from 'clsx';
-import { compact, noop, sortBy, without } from 'lodash-es';
+import { compact, noop, without } from 'lodash-es';
 import { FC, useCallback, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useSelector } from 'react-redux';
@@ -20,6 +20,7 @@ import {
 import { LANGUAGES } from '@visitor-space/components/LanguageFilterForm/languages';
 import { visitorSpaceLabelKeys } from '@visitor-space/const';
 import { FILTER_LABEL_VALUE_DELIMITER, VisitorSpaceFilterId } from '@visitor-space/types';
+import { sortFilterOptions } from '@visitor-space/utils/sort-filter-options';
 
 const defaultValues = {
 	languages: [],
@@ -61,16 +62,13 @@ const LanguageFilterForm: FC<LanguageFilterFormProps> = ({ children, className }
 	// Make sure applied values are sorted at the top of the list
 	// Options selected by the user should remain in their alphabetical order until the filter is applied
 	// https://meemoo.atlassian.net/browse/ARC-1882
-	const checkboxOptions = sortBy(
+	const checkboxOptions = sortFilterOptions(
 		filteredOptions.map((filterOption) => ({
 			label: LANGUAGES.nl[filterOption] || filterOption,
 			value: filterOption,
 			checked: selectedLanguageCodes.includes(filterOption),
 		})),
-		(option) =>
-			(appliedSelectedLanguageCodes.includes(option.value) ? '0' : '1') +
-			'___' +
-			option.label.toLowerCase()
+		appliedSelectedLanguageCodes
 	);
 
 	const idToIdAndNameConcatinated = useCallback((id: string) => {

--- a/src/modules/visitor-space/components/MaintainerFilterForm/MaintainerFilterForm.tsx
+++ b/src/modules/visitor-space/components/MaintainerFilterForm/MaintainerFilterForm.tsx
@@ -1,7 +1,7 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import { CheckboxList } from '@meemoo/react-components';
 import clsx from 'clsx';
-import { compact, keyBy, mapValues, noop, sortBy, without } from 'lodash-es';
+import { compact, keyBy, mapValues, noop, without } from 'lodash-es';
 import { FC, useCallback, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useSelector } from 'react-redux';
@@ -15,6 +15,7 @@ import { MaintainerFilterFormProps, MaintainerFilterFormState } from '@visitor-s
 import { visitorSpaceLabelKeys } from '@visitor-space/const';
 import { useGetContentPartners } from '@visitor-space/hooks/get-content-partner';
 import { FILTER_LABEL_VALUE_DELIMITER, VisitorSpaceFilterId } from '@visitor-space/types';
+import { sortFilterOptions } from '@visitor-space/utils/sort-filter-options';
 
 import {
 	MAINTAINER_FILTER_FORM_QUERY_PARAM_CONFIG,
@@ -55,9 +56,9 @@ const MaintainerFilterForm: FC<MaintainerFilterFormProps> = ({ children, classNa
 		(v) => v.name
 	);
 
-	const filterOptions: { id: string; name: string }[] = useSelector(
-		selectIeObjectsFilterOptions
-	)?.[IeObjectsSearchFilterField.MAINTAINER_ID];
+	const filterOptions: { id: string; name: string }[] = useSelector(selectIeObjectsFilterOptions)[
+		IeObjectsSearchFilterField.MAINTAINER_ID
+	];
 
 	const filteredBuckets = filterOptions.filter((filterOption) =>
 		filterOption.name.toLowerCase().includes(search.toLowerCase())
@@ -66,7 +67,7 @@ const MaintainerFilterForm: FC<MaintainerFilterFormProps> = ({ children, classNa
 	// Make sure applied values are sorted at the top of the list
 	// Options selected by the user should remain in their alphabetical order until the filter is applied
 	// https://meemoo.atlassian.net/browse/ARC-1882
-	const checkboxOptions = sortBy(
+	const checkboxOptions = sortFilterOptions(
 		filteredBuckets.map((filterOption) => {
 			return {
 				label: filterOption.name,
@@ -74,10 +75,7 @@ const MaintainerFilterForm: FC<MaintainerFilterFormProps> = ({ children, classNa
 				checked: selectedMaintainerIds.includes(filterOption.id),
 			};
 		}),
-		(filterOption) =>
-			(appliedSelectedMaintainerIds.includes(filterOption.value) ? '0' : '1') +
-			'___' +
-			filterOption.label.toLowerCase()
+		appliedSelectedMaintainerIds
 	);
 
 	const idToIdAndNameConcatinated = useCallback(

--- a/src/modules/visitor-space/components/MediumFilterForm/MediumFilterForm.tsx
+++ b/src/modules/visitor-space/components/MediumFilterForm/MediumFilterForm.tsx
@@ -1,7 +1,7 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import { CheckboxList } from '@meemoo/react-components';
 import clsx from 'clsx';
-import { compact, noop, sortBy, without } from 'lodash-es';
+import { compact, noop, without } from 'lodash-es';
 import { FC, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useSelector } from 'react-redux';
@@ -13,6 +13,7 @@ import { selectIeObjectsFilterOptions } from '@shared/store/ie-objects/ie-object
 import { IeObjectsSearchFilterField } from '@shared/types';
 import { visitorSpaceLabelKeys } from '@visitor-space/const';
 import { VisitorSpaceFilterId } from '@visitor-space/types';
+import { sortFilterOptions } from '@visitor-space/utils/sort-filter-options';
 
 import {
 	MEDIUM_FILTER_FORM_QUERY_PARAM_CONFIG,
@@ -53,16 +54,13 @@ const MediumFilterForm: FC<MediumFilterFormProps> = ({ children, className }) =>
 	// Make sure applied values are sorted at the top of the list
 	// Options selected by the user should remain in their alphabetical order until the filter is applied
 	// https://meemoo.atlassian.net/browse/ARC-1882
-	const checkboxOptions = sortBy(
+	const checkboxOptions = sortFilterOptions(
 		filteredOptions.map((filterOption) => ({
 			label: filterOption,
 			value: filterOption,
 			checked: selectedMediums.includes(filterOption),
 		})),
-		(option) =>
-			(appliedSelectedMediums.includes(option.value) ? '0' : '1') +
-			'___' +
-			option.value.toLowerCase()
+		appliedSelectedMediums
 	);
 
 	// Effects

--- a/src/modules/visitor-space/components/MediumSelect/MediumSelect.tsx
+++ b/src/modules/visitor-space/components/MediumSelect/MediumSelect.tsx
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux';
 import useTranslation from '@shared/hooks/use-translation/use-translation';
 import { selectIeObjectsFilterOptions } from '@shared/store/ie-objects/ie-objects.select';
 import { IeObjectsSearchFilterField } from '@shared/types';
+import { sortFilterOptions } from '@visitor-space/utils/sort-filter-options';
 
 const MediumSelect: FC<ReactSelectProps> = (props) => {
 	const { tText } = useTranslation();
@@ -12,11 +13,13 @@ const MediumSelect: FC<ReactSelectProps> = (props) => {
 		IeObjectsSearchFilterField.MEDIUM
 	];
 
-	const selectOptions = filterOptions.map((filterOption) => ({
-		// label: `${bucket.key} (${bucket.doc_count})`, // Disabled due to non-representative scale of results
-		label: filterOption,
-		value: filterOption,
-	}));
+	const selectOptions = sortFilterOptions(
+		filterOptions.map((filterOption) => ({
+			label: filterOption,
+			value: filterOption,
+		})),
+		[]
+	);
 
 	// Bind to defaultProps to access externally
 	MediumSelect.defaultProps = { options: selectOptions };

--- a/src/modules/visitor-space/components/ObjectTypeSelect/ObjectTypeSelect.tsx
+++ b/src/modules/visitor-space/components/ObjectTypeSelect/ObjectTypeSelect.tsx
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux';
 import useTranslation from '@shared/hooks/use-translation/use-translation';
 import { selectIeObjectsFilterOptions } from '@shared/store/ie-objects/ie-objects.select';
 import { IeObjectsSearchFilterField } from '@shared/types';
+import { sortFilterOptions } from '@visitor-space/utils/sort-filter-options';
 
 const ObjectTypeSelect: FC<ReactSelectProps> = (props) => {
 	const { tText } = useTranslation();
@@ -12,11 +13,13 @@ const ObjectTypeSelect: FC<ReactSelectProps> = (props) => {
 		IeObjectsSearchFilterField.OBJECT_TYPE
 	];
 
-	const options = filterOptions.map((option) => ({
-		// label: `${bucket.key} (${bucket.doc_count})`, // Disabled due to non-representative scale of results
-		label: option,
-		value: option,
-	}));
+	const options = sortFilterOptions(
+		filterOptions.map((option) => ({
+			label: option,
+			value: option,
+		})),
+		[]
+	);
 
 	// Bind to defaultProps to access externally
 	ObjectTypeSelect.defaultProps = { options };

--- a/src/modules/visitor-space/utils/sort-filter-options.ts
+++ b/src/modules/visitor-space/utils/sort-filter-options.ts
@@ -1,0 +1,36 @@
+import { sortBy } from 'lodash-es';
+
+enum CharacterType {
+	LETTER = 0,
+	NUMBER = 1,
+	SYMBOL = 2,
+}
+
+function getCharacterType(firstCharacter: string): CharacterType {
+	if (/[A-Za-z]/.test(firstCharacter)) {
+		return CharacterType.LETTER;
+	}
+	if (/[0-9]/.test(firstCharacter)) {
+		return CharacterType.NUMBER;
+	}
+	return CharacterType.SYMBOL;
+}
+
+export function sortFilterOptions(
+	options: { label: string; value: string }[],
+	appliedOptionValues: string[]
+): {
+	label: string;
+	value: string;
+}[] {
+	return sortBy(
+		options,
+		(filterOption) =>
+			// Sort checked options first
+			(appliedOptionValues.includes(filterOption.value) ? '0' : '1') +
+			// Sort letters, then numbers, then symbols
+			getCharacterType(filterOption.label[0]) +
+			// Then sort by lowercase label
+			filterOption.label.toLowerCase()
+	);
+}


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1943


change default sorting so letters come first, then digits and then special symbols

![image](https://github.com/viaacode/hetarchief-client/assets/1710840/2b594edb-80e6-4925-a786-50fc4512a1da)

![image](https://github.com/viaacode/hetarchief-client/assets/1710840/19f2f0aa-eac1-4bf4-9383-e42de7be717f)
