### PR TITLE
fix(arc-1942): fix buttons outline overflowing

### DIFF
--- a/src/styles/admin-core/_content-pages-preview.scss
+++ b/src/styles/admin-core/_content-pages-preview.scss
@@ -146,6 +146,7 @@ $l-container-padding-xs: 2rem;
 		border-radius: 4rem;
 		border-style: solid !important;
 		font-family: $font-family-primary;
+		margin: 0.2rem; // ARC-1942: make sure outline is not overflowing
 	}
 
 	.c-button--content-page-button--silver {


### PR DESCRIPTION
Before:
<img width="154" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/5ba41433-15e2-4e62-a6ce-56d28f2fcf3c">


After:
<img width="173" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/7a79d611-30bf-4d0e-9372-8a628e1976d8">


Ticket: https://meemoo.atlassian.net/browse/ARC-1942