### PR TITLE
fix(arc-1965): show visitor space no longer active error

### DIFF
--- a/src/pages/bezoek/[slug]/index.tsx
+++ b/src/pages/bezoek/[slug]/index.tsx
@@ -88,10 +88,11 @@ const VisitPage: NextPage<VisitPageProps> = () => {
 		if (!isLoggedIn) {
 			return renderNoAccess();
 		} else {
-			if (visitorSpaceInfo) {
-				if (isErrorSpaceNotActive) {
-					return <ErrorSpaceNoLongerActive />;
-				} else if (hasPendingRequest) {
+			if (isErrorSpaceNotActive) {
+				// Visitor space no longer active
+				return <ErrorSpaceNoLongerActive />;
+			} else if (visitorSpaceInfo) {
+				if (hasPendingRequest) {
 					// Redirect to the waiting page
 					return (
 						<>


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1965

show error when visiting inactive visitor space:
http://localhost:3200/bezoek/industriemuseum

![image](https://github.com/viaacode/hetarchief-client/assets/1710840/15f56a19-329f-4351-acc9-fc45751cb2ce)
