### PR TITLE
fix(filter-footer-overflow): reduce filter body maxheight

### DIFF
--- a/src/modules/visitor-space/components/FilterMenu/FilterForm/FilterForm.module.scss
+++ b/src/modules/visitor-space/components/FilterMenu/FilterForm/FilterForm.module.scss
@@ -30,7 +30,7 @@
 }
 
 .c-filter-form__body {
-	max-height: 45vh;
+	max-height: 40vh;
 	overflow-y: auto;
 
 	// Allow "overflowing" effects on input fields


### PR DESCRIPTION
Before:
<img width="833" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/9263b502-2dcd-4ecb-9421-1d62f73c14dc">


After:
<img width="792" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/d3b9ec7f-25f1-49bd-8d9d-43d2b15579cd">


