### PR TITLE
feat(arc-1903): switch overlay logo to right

### DIFF
--- a/src/styles/components/_flowplayer.scss
+++ b/src/styles/components/_flowplayer.scss
@@ -2,7 +2,7 @@
 	margin: 3.2rem;
 	position: absolute;
 	top: 0;
-	left: 0;
+	right: 0;
 	width: 7%;
 	opacity: 0.5;
 	pointer-events: none;


### PR DESCRIPTION
<img width="828" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/22f936b5-462d-4948-9b36-a4148c16c4e5">


Ticket: https://meemoo.atlassian.net/browse/ARC-1903