### PR TITLE
fix(ARC-1960): change styling so desktop columns are still 50% of width

### DIFF
--- a/src/styles/admin-core/content-blocks/_content-block-two-columns.scss
+++ b/src/styles/admin-core/content-blocks/_content-block-two-columns.scss
@@ -6,13 +6,24 @@ $component: "c-content-block__rich-text-two-columns";
 	grid-template-columns: unset !important;
 
 	.o-grid {
+		margin-left: 0;
+		margin-right: 0;
+		grid-template-columns: repeat(auto-fill, minmax(40rem, 1fr));
 		width: 100%;
 		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(26rem, 1fr));
 		grid-gap: $spacer-1xl;
 
 		.o-grid-col-bp2-6 {
-			width: calc(100% - 4rem) !important;
+			width: calc(100% - $spacer-1xl / 2) !important;
+		}
+
+		/* https://meemoo.atlassian.net/browse/ARC-1960 */
+		@include respond-to("md") {
+			grid-template-columns: repeat(auto-fill, 1fr);
+
+			.o-grid-col-bp2-6 {
+				width: calc(100% - $spacer-1xl) !important;
+			}
 		}
 	}
 


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1960

after desktop:
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/75f3dcc4-980e-491c-86a6-fc84493dc291)

after mobile:
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/60161285-faf8-42af-b105-23ed1821d737)
