### PR TITLE
fix(ARC-1961): allow long words to be broken in folder name

### DIFF
--- a/src/styles/components/_content-input.scss
+++ b/src/styles/components/_content-input.scss
@@ -25,8 +25,8 @@ $component: "c-content-input";
 		flex-grow: 1;
 		outline: none;
 		padding: 0;
-		word-break: normal;
-		line-break: inherit;
+		line-break: auto;
+		word-break: break-word;
 
 		&::first-line {
 			vertical-align: middle;


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1961

http://localhost:3200/account/mijn-mappen

before:
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/aaab9866-7343-407e-a919-c723aad4808c)


after:
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/543a00ed-9f75-4788-878c-8e5e3b803fdd)
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/f398e26b-7d5f-43aa-8986-400b2e3600c2)
