### PR TITLE
fix(ARC-2008): allow word break in obj title in material request blade

### DIFF
--- a/src/modules/visitor-space/components/MaterialRequestBlade/MaterialRequestBlade.module.scss
+++ b/src/modules/visitor-space/components/MaterialRequestBlade/MaterialRequestBlade.module.scss
@@ -41,6 +41,7 @@ $component: "c-request-material";
 		&-label {
 			font-weight: 900;
 			margin-bottom: $spacer-xxs;
+			word-break: break-word;
 
 			&-icon {
 				color: $blue;


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-2008


before:
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/7af8f8c4-c00a-445e-bbb2-f23a8eedfefc)


after:
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/f6adaa80-9582-4f1b-8dc8-71b10a4c8574)
