### PR TITLE
fix(ARC-2004): show maintainer name instead of slug on no access page

### DIFF
--- a/src/pages/bezoek/[slug]/index.tsx
+++ b/src/pages/bezoek/[slug]/index.tsx
@@ -69,7 +69,7 @@ const VisitPage: NextPage<VisitPageProps> = () => {
 				description={tText(
 					'pages/bezoek/slug/index___je-hebt-geen-toegang-tot-deze-bezoekersruimte-vraag-toegang-aan-of-doorzoek-de-publieke-catalogus'
 				)}
-				visitorSpaceName={(slug || null) as string | null}
+				visitorSpaceName={(visitorSpaceInfo?.name || slug || null) as string | null}
 				visitorSpaceSlug={(slug || null) as string | null}
 			/>
 		);


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-2004

before:
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/43758a52-7915-49a8-b2c4-251ba092e304)
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/40894a8e-8e01-4f69-b1e4-ed3d90c7bb86)


after:
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/a0eebd90-eee5-4621-87fd-e2701deb2d34)
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/8ce3439d-3194-4bee-bb03-bfbc45d51e3f)

