### PR TITLE
fix(ARC-2000): show no video icon on related objects on mobile

### DIFF
--- a/src/modules/ie-objects/components/ObjectPlaceholder/ObjectPlaceholder.module.scss
+++ b/src/modules/ie-objects/components/ObjectPlaceholder/ObjectPlaceholder.module.scss
@@ -87,12 +87,6 @@ $component: "c-object-placeholder";
 			width: $card-image-small-width-md;
 			min-width: $card-image-small-width-md;
 		}
-
-		@include respond-to("md") {
-			.#{$component}__page {
-				display: none;
-			}
-		}
 	}
 
 	&__visit-button {


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-2000

before:
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/ce2fc0d9-f184-49e6-a9d2-ff635201cd15)

after:
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/5e9cc8ce-0085-442c-8acc-06b9e055087f)
