### PR TITLE
fix(ARC-1997): fix vert alignment in image grid on narrow screens

### DIFF
--- a/src/styles/admin-core/_content-pages-preview.scss
+++ b/src/styles/admin-core/_content-pages-preview.scss
@@ -116,10 +116,12 @@ $l-container-padding-xs: 2rem;
 
 	// USP Block, Image grid block
 	.c-block-grid {
-		align-items: center;
+		align-items: flex-start;
 
-		@include respond-at("lg") {
-			align-items: flex-start;
+		@include respond-to("md") {
+			justify-content: center;
+			flex-direction: column;
+			align-content: center;
 		}
 
 		.c-block-grid__text-wrapper {


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-1997

before:
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/f928e616-a687-470a-b5c2-8b8991c64854)
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/7a7fdf82-6cff-4e14-97f2-f4324b68ad92)


after:
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/763c33ae-4922-4939-a8fd-6a4e7486e337)
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/1c010a85-4661-4c00-a517-2301498a4f5b)

