### PR TITLE
fix(arc-2001): whole card disabled view when no link

### DIFF
--- a/src/modules/shared/components/MediaCard/MediaCard.module.scss
+++ b/src/modules/shared/components/MediaCard/MediaCard.module.scss
@@ -22,6 +22,10 @@ $c-media-card-no-video-intended-spacing: 0.9rem;
 		}
 	}
 
+	&__no-content-icon {
+		color: $grey !important;
+	}
+
 	&--pointer {
 		cursor: pointer;
 	}

--- a/src/modules/shared/components/MediaCard/MediaCard.module.scss
+++ b/src/modules/shared/components/MediaCard/MediaCard.module.scss
@@ -15,6 +15,7 @@ $c-media-card-no-video-intended-spacing: 0.9rem;
 
 	&:global(.c-media-card--no-link) {
 		cursor: default !important;
+		background-color: $silver;
 
 		:global(.c-card__title-wrapper) {
 			color: $grey;

--- a/src/modules/shared/components/MediaCard/MediaCard.tsx
+++ b/src/modules/shared/components/MediaCard/MediaCard.tsx
@@ -191,7 +191,9 @@ const MediaCard: FC<MediaCardProps> = ({
 
 	const renderNoContentIcon = () => (
 		<Icon
-			className={clsx(styles['c-media-card__no-content'], styles['c-media-card__icon'])}
+			className={clsx(styles['c-media-card__no-content'], styles['c-media-card__icon'], {
+				[styles['c-media-card__no-content-icon']]: !link,
+			})}
 			name={TYPE_TO_NO_ICON_MAP[type as Exclude<IeObjectTypes, null>]}
 		/>
 	);


### PR DESCRIPTION
<img width="1389" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/c3077a46-b33e-4738-a94f-18b2d1fa43e3">


Ticket: https://meemoo.atlassian.net/browse/ARC-2001