### PR TITLE
fix(arc-905): use min-width to display icon on iPhone

### DIFF
--- a/src/modules/shared/components/VisitorSpaceCard/VisitorSpaceCard.module.scss
+++ b/src/modules/shared/components/VisitorSpaceCard/VisitorSpaceCard.module.scss
@@ -80,7 +80,7 @@ $component: "c-visitor-space-card";
 
 			&--icon {
 				margin-top: auto;
-				width: 2rem;
+				min-width: 2rem;
 			}
 		}
 


### PR DESCRIPTION
Before:

<img width="317" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/f848e471-29c0-4b33-9092-bc204ef6940d">



After:

<img width="315" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/5574f2f3-ce50-4e74-b418-8d981c549d00">


Ticket: https://meemoo.atlassian.net/browse/ARC-905