### PR TITLE
fix(arc-2019): remove nav items z-index

### DIFF
--- a/src/modules/navigation/components/Navigation/Navigation.module.scss
+++ b/src/modules/navigation/components/Navigation/Navigation.module.scss
@@ -294,7 +294,6 @@ $c-navigation-decoration: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDo
 }
 
 .c-navigation__item {
-	z-index: get-z-layer("nav-dropdown") + 1;
 	display: inline-flex;
 	align-items: center;
 	transition:


### PR DESCRIPTION
<img width="1010" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/f6244ea8-e395-4e99-b911-841bd7101a49">


Ticket: https://meemoo.atlassian.net/browse/ARC-2019