### PR TITLE
fix(ARC-2023): make date input component default value empty

### DIFF
--- a/src/modules/shared/components/ApproveRequestBlade/ApproveRequestBlade.helpers.ts
+++ b/src/modules/shared/components/ApproveRequestBlade/ApproveRequestBlade.helpers.ts
@@ -12,7 +12,7 @@ export const roundToNextQuarter = (oldDate: Date): Date => {
 };
 
 /**
- * Determines if we should set the end date of an visit request when the user change the start date
+ * Determines if we should set the end date of a visit request when the user change the start date
  *
  * @param newAccessFromDate newly entered date for the accessFrom field modified by the user
  * @param currentAccessToDate existing accessTo field value

--- a/src/modules/shared/helpers/convert-year-to-date.ts
+++ b/src/modules/shared/helpers/convert-year-to-date.ts
@@ -1,0 +1,17 @@
+import { SEPARATOR } from '@shared/const';
+import { Operator } from '@shared/types';
+
+export function convertYearToDate(yearString: string, operator: Operator): string {
+	const startOfYear = `${yearString}-01-01T00:00:00Z`;
+	const endOfYear = `${yearString}-12-31T23:59:59Z`;
+
+	if (operator === Operator.Equals) {
+		return `${startOfYear}${SEPARATOR}${endOfYear}`;
+	}
+
+	if (operator === Operator.LessThanOrEqual) {
+		return endOfYear;
+	}
+
+	return startOfYear;
+}

--- a/src/modules/visitor-space/components/DateInput/DateInput.tsx
+++ b/src/modules/visitor-space/components/DateInput/DateInput.tsx
@@ -25,6 +25,7 @@ export interface DateInputProps {
 	onBlur?: (evt: Event) => void;
 	value?: Date;
 	className?: string;
+	defaultValue?: Date;
 }
 
 const DateInput: FC<DateInputProps> = ({
@@ -35,6 +36,7 @@ const DateInput: FC<DateInputProps> = ({
 	label,
 	onBlur = noop,
 	className,
+	defaultValue,
 }) => {
 	return (
 		<div className={styles['c-date-input']}>
@@ -46,7 +48,7 @@ const DateInput: FC<DateInputProps> = ({
 				onBlur={onBlur}
 				className={className}
 				disabled={disabled}
-				selected={isValid(value) ? value : new Date()}
+				selected={isValid(value) ? value : defaultValue}
 				dateFormat="dd/MM/yyyy"
 				placeholderText="dd/mm/jjjj"
 				customInput={<TextInput iconStart={<Icon name={IconNamesLight.Calendar} />} />}

--- a/src/modules/visitor-space/components/DateRangeInput/DateRangeInput.tsx
+++ b/src/modules/visitor-space/components/DateRangeInput/DateRangeInput.tsx
@@ -8,9 +8,9 @@ import styles from './DateRangeInput.module.scss';
 
 export interface DateRangeInputProps {
 	showLabels?: boolean;
-	from: Date;
-	to: Date;
-	onChange: (from: Date, to: Date) => void;
+	from: Date | undefined;
+	to: Date | undefined;
+	onChange: (from: Date | undefined, to: Date | undefined) => void;
 	disabled?: boolean;
 	id?: string;
 }

--- a/src/modules/visitor-space/components/PublishedFilterForm/PublishedFilterForm.tsx
+++ b/src/modules/visitor-space/components/PublishedFilterForm/PublishedFilterForm.tsx
@@ -2,12 +2,13 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { FormControl, ReactSelect, SelectOption } from '@meemoo/react-components';
 import clsx from 'clsx';
 import { endOfDay, parseISO, startOfDay } from 'date-fns';
-import { FC, useCallback, useEffect, useMemo, useState } from 'react';
+import { ChangeEvent, FC, useEffect, useMemo, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { SingleValue } from 'react-select';
+import { MultiValue, SingleValue } from 'react-select';
 import { useQueryParams } from 'use-query-params';
 
 import { SEPARATOR } from '@shared/const';
+import { convertYearToDate } from '@shared/helpers/convert-year-to-date';
 import useTranslation from '@shared/hooks/use-translation/use-translation';
 import { isRange, Operator } from '@shared/types';
 import {
@@ -42,9 +43,9 @@ const PublishedFilterForm: FC<PublishedFilterFormProps> = ({ children, className
 	const { tHtml } = useTranslation();
 	const [query] = useQueryParams(PUBLISHED_FILTER_FORM_QUERY_PARAM_CONFIG);
 
-	const initial = query?.published?.[0];
+	const initialValue = query?.published?.[0];
 
-	const [showRange, setShowRange] = useState(isRange(initial?.op));
+	const [showRange, setShowRange] = useState(isRange(initialValue?.op));
 	const [form, setForm] = useState<PublishedFilterFormState>(defaultValues);
 	const [yearsSelected, setYearsSelected] = useState(false);
 	const [year, setYear] = useState<string | undefined>(undefined);
@@ -72,15 +73,15 @@ const PublishedFilterForm: FC<PublishedFilterFormProps> = ({ children, className
 	}, [form, setValue]);
 
 	useEffect(() => {
-		if (initial) {
-			const { val, op } = initial;
+		if (initialValue) {
+			const { val, op } = initialValue;
 
 			val && setForm((oldForm) => ({ ...oldForm, published: val }));
 			op && setForm((oldForm) => ({ ...oldForm, operator: op as Operator }));
 
 			setShowRange(isRange(op)); // Not covered by other useEffects in time
 		}
-	}, [initial]);
+	}, [initialValue]);
 
 	// Events
 
@@ -97,40 +98,56 @@ const PublishedFilterForm: FC<PublishedFilterFormProps> = ({ children, className
 		}
 	};
 
+	const onChangeYear = (e: ChangeEvent<HTMLInputElement>) => {
+		const isNumberReg = new RegExp(/^\d+$/);
+		const isNumber = isNumberReg.test(e.target.value) || e.target.value === '';
+
+		if (isNumber && e.target.value.length < 5) {
+			setYear(e.target.value);
+		}
+	};
+
+	const onChangeDateInput = (newDate: Date | null) => {
+		if (!newDate) {
+			setForm((oldForm) => ({ ...oldForm, published: undefined }));
+			return;
+		}
+		if (form.operator === Operator.Equals) {
+			convertToRange(newDate);
+			return;
+		}
+		onChangePublished((newDate || new Date()).toISOString());
+	};
+
 	const onChangePublished = (published: string) => {
 		setForm((oldForm) => ({ ...oldForm, published }));
 	};
 
-	const convertYearToDate = useCallback(
-		(yearString: string) => {
-			const startOfYear = `${yearString}-01-01T00:00:00Z`;
-			const endOfYear = `${yearString}-12-31T23:59:59Z`;
-
-			if (form.operator === Operator.Equals) {
-				return `${startOfYear}${SEPARATOR}${endOfYear}`;
-			}
-
-			if (form.operator === Operator.LessThanOrEqual) {
-				return endOfYear;
-			}
-
-			return startOfYear;
-		},
-		[form.operator]
-	);
-
 	useEffect(() => {
 		if (year) {
-			const yearDate = convertYearToDate(year)?.toString();
+			const yearDate = convertYearToDate(year, form.operator)?.toString();
 			setForm((oldForm) => ({ ...oldForm, published: yearDate }));
 		}
-	}, [year, convertYearToDate, setForm]);
+	}, [year, setForm, form.operator]);
 
 	useEffect(() => {
 		if (yearRange) {
 			setForm((oldForm) => ({ ...oldForm, published: yearRange }));
 		}
 	}, [yearRange, setForm]);
+
+	const onChangeOperatorSelect = (
+		operator: SingleValue<SelectOption> | MultiValue<SelectOption>
+	) => {
+		const value = (operator as SingleValue<SelectOption>)?.value as Operator;
+
+		if (value !== form.operator) {
+			setForm({
+				operator: value,
+				published: defaultValues.published,
+			});
+		}
+	};
 
 	const renderInputField = () => {
 		if (yearsSelected && showRange) {
@@ -149,17 +166,19 @@ const PublishedFilterForm: FC<PublishedFilterFormProps> = ({ children, className
 		if (showRange) {
 			const split = ((form.published || '') as string).split(SEPARATOR, 2);
 
-			const from: Date = split[0] ? parseISO(split[0]) : new Date();
-			const to: Date = split[1] ? parseISO(split[1]) : new Date();
+			const from: Date | undefined = split[0] ? parseISO(split[0]) : undefined;
+			const to: Date | undefined = split[1] ? parseISO(split[1]) : undefined;
 
 			return (
 				<DateRangeInput
 					disabled={disabled}
 					showLabels
 					id="published"
-					onChange={(newFromDate: Date, newToDate: Date) => {
+					onChange={(newFromDate: Date | undefined, newToDate: Date | undefined) => {
 						onChangePublished(
-							`${newFromDate.toISOString()}${SEPARATOR}${newToDate.toISOString()}`
+							`${newFromDate ? newFromDate.toISOString() : ''}${SEPARATOR}${
+								newToDate ? newToDate.toISOString() : ''
+							}`
 						);
 					}}
 					from={from}
@@ -173,30 +192,21 @@ const PublishedFilterForm: FC<PublishedFilterFormProps> = ({ children, className
 					label={getSelectValue(operators, form.operator)?.label}
 					disabled={disabled}
 					id="published"
-					onChange={(e) => {
-						if (e.target.value.length < 5) {
-							setYear(e.target.value);
-						}
-					}}
+					onChange={(e) => onChangeYear(e)}
 					value={year}
 				/>
 			);
 		}
+		const value = form.published?.split(SEPARATOR, 2)[0];
 		return (
 			<DateInput
 				label={getSelectValue(operators, form.operator)?.label}
 				disabled={disabled}
 				id="published"
 				onChange={(date) => {
-					if (form.operator === Operator.Equals) {
-						convertToRange(date || new Date());
-						return;
-					}
-					onChangePublished(date.toISOString());
+					onChangeDateInput(date);
 				}}
-				value={
-					form.published ? parseISO(form.published.split(SEPARATOR, 2)[0]) : new Date()
-				}
+				value={value ? parseISO(value) : undefined}
 			/>
 		);
 	};
@@ -231,15 +241,7 @@ const PublishedFilterForm: FC<PublishedFilterFormProps> = ({ children, className
 									components={{ IndicatorSeparator: () => null }}
 									inputId={labelKeys.operator}
 									onChange={(newValue) => {
-										const value = (newValue as SingleValue<SelectOption>)
-											?.value as Operator;
-
-										if (value !== form.operator) {
-											setForm({
-												operator: value,
-												published: defaultValues.published,
-											});
-										}
+										onChangeOperatorSelect(newValue);
 									}}
 									options={operators}
 									value={getSelectValue(operators, field.value)}


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-2023

make default values of date picker filters undefined instead of today

![image](https://github.com/viaacode/hetarchief-client/assets/1710840/7d3175cd-a6bc-4b89-982a-392f103dd93e)

![image](https://github.com/viaacode/hetarchief-client/assets/1710840/57986b64-5463-434d-963a-9d4bf774fc03)
