### PR TITLE
fix(arc-2033): navbar highlight fix

### DIFF
--- a/src/modules/navigation/components/Navigation/Navigation.module.scss
+++ b/src/modules/navigation/components/Navigation/Navigation.module.scss
@@ -176,10 +176,10 @@ $c-navigation-decoration: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDo
 	.c-navigation__list-overlay {
 		width: 100vw;
 		position: absolute;
-		padding-top: $c-navigation-height-md;
+		margin-top: $c-navigation-height-md;
 
 		@include respond-at(xxl) {
-			padding-top: $c-navigation-height;
+			margin-top: $c-navigation-height;
 		}
 	}
 
@@ -221,6 +221,7 @@ $c-navigation-decoration: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDo
 
 	.c-navigation__list-flyout {
 		color: $black;
+		z-index: get-z-layer("nav-dropdown") + 1;
 
 		// Overwrite popper element styles
 		@include respond-to(xxl) {


### PR DESCRIPTION
<img width="1692" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/eb4aa9ae-5fa7-4189-bb28-88a70326569d">


Ticket: https://meemoo.atlassian.net/browse/ARC-2033