### PR TITLE
fix(arc-2021): hide buttons if no maintainerslug

### DIFF
--- a/src/pages/account/mijn-mappen/[folderSlug]/index.tsx
+++ b/src/pages/account/mijn-mappen/[folderSlug]/index.tsx
@@ -256,6 +256,10 @@ const AccountMyFolders: NextPage<DefaultSeoInfo> = ({ url }) => {
 	 * @param item
 	 */
 	const getShowLocallyAvailableLabel = (item: FolderIeObject) => {
+		// ARC-2021: Do not show locally available label if no visitor space
+		if (!item.maintainerSlug) {
+			return false;
+		}
 		return (
 			isEmpty(item.accessThrough) &&
 			(item.licenses?.includes(IeObjectLicense.BEZOEKERTOOL_METADATA_ALL) ||
@@ -271,6 +275,10 @@ const AccountMyFolders: NextPage<DefaultSeoInfo> = ({ url }) => {
 	 * @param item
 	 */
 	const getShowPlanVisitButtons = (item: FolderIeObject) => {
+		// ARC-2021: Do not show plan visit buttons if no visitor space
+		if (!item.maintainerSlug) {
+			return false;
+		}
 		return (
 			isEmpty(item.accessThrough) &&
 			(item.licenses?.includes(IeObjectLicense.BEZOEKERTOOL_METADATA_ALL) ||


### PR DESCRIPTION
Before:
<img width="1529" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/db659b3a-8c2d-422f-ab25-bf3c313eff93">


After:

<img width="1537" alt="image" src="https://github.com/viaacode/hetarchief-client/assets/113892598/d57693f2-fa16-46c9-971c-5e798a2dbb80">


Ticket: https://meemoo.atlassian.net/browse/ARC-2021