### PR TITLE
feat(translations-sql): use new transl. endp., fix transl.editor styling

### DIFF
--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -9,13 +9,13 @@ module.exports = {
 			defaultLocale: 'nl',
 			locales: ['nl'],
 			backend: {
-				loadPath: `${proxyUrl}/translations/nl.json`,
+				loadPath: `${proxyUrl}/translations/NL.json`,
 			},
 			i18n: {
 				defaultLocale: 'nl',
 				locales: ['nl'],
 				backend: {
-					loadPath: `${proxyUrl}/translations/nl.json`,
+					loadPath: `${proxyUrl}/translations/NL.json`,
 				},
 			},
 			use: [I18NextHttpBackend],

--- a/src/modules/i18n/helpers/get-translations.ts
+++ b/src/modules/i18n/helpers/get-translations.ts
@@ -2,12 +2,12 @@ import { ApiService } from '@shared/services/api-service';
 
 export async function getTranslations(): Promise<Record<string, string>> {
 	try {
-		return await ApiService.getApi(true).get('admin/translations/nl.json').json();
+		return await ApiService.getApi(true).get('admin/translations/NL.json').json();
 	} catch (err) {
 		console.error({
 			message: 'Failed to fetch translations from the backend',
 			innerException: err,
-			additionalInfo: 'admin/translations/nl.json',
+			additionalInfo: 'admin/translations/NL.json',
 		});
 		return {};
 	}

--- a/src/pages/admin/vertalingen/TranslationsOverview.module.scss
+++ b/src/pages/admin/vertalingen/TranslationsOverview.module.scss
@@ -22,15 +22,34 @@
 	:global(table) {
 		margin-top: $spacer-md;
 
-		:global(.c-table__row:hover) {
-			background-color: $platinum;
-			cursor: pointer;
+		:global(.c-table__cell--header) {
+			text-align: left;
+			padding-left: $spacer-md;
 		}
 
-		:global(.c-table__row--header) {
-			:global(.c-table__cell--header) {
-				:global(> span) {
-					font-size: $font-size-base;
+		:global(.c-table__row) {
+			:global(> td:first-child) {
+				width: 40%;
+			}
+
+			:global(> td:not(:first-child)) {
+				width: 30%;
+				padding: 0;
+
+				> button {
+					padding: $spacer-md;
+					min-height: 10rem;
+					font-family: SofiaPro, sans-serif;
+					font-size: $font-size-sm;
+
+					&:global(:hover) {
+						background-color: $platinum;
+						cursor: pointer;
+					}
+
+					p {
+						font-size: $font-size-sm;
+					}
 				}
 			}
 		}
@@ -38,20 +57,7 @@
 		:global(.u-text-muted) {
 			color: $neutral;
 		}
-
-		:global(.c-table__cell:last-child) {
-			width: 6rem;
-
-			:global(> span) {
-				font-size: $font-size-2xm;
-				margin-top: 0.4rem;
-			}
-		}
 	}
-}
-
-.c-translations-overview__blade:global(.c-blade--active) {
-	width: 70rem;
 }
 
 .c-translations-overview__blade-body {
@@ -59,6 +65,22 @@
 
 	:global(.c-rich-text-editor) {
 		margin-top: $spacer-md;
+	}
+
+	:global(.c-translation-overview__textarea) {
+		width: 100%;
+		min-height: 57.2rem; // Same height as rich text editor
+		border: 1px solid $zinc;
+		border-radius: 0;
+		padding: 1.5rem;
+		font-family: SofiaPro, sans-serif;
+		font-size: $font-size-base;
+		outline: none;
+
+		&:global(:focus-visible),
+		&:global(:active) {
+			border: 1px solid $teal;
+		}
 	}
 
 	:global(.c-button--copy-to-clipboard) {

--- a/src/styles/pages/admin/_translations.scss
+++ b/src/styles/pages/admin/_translations.scss
@@ -6,36 +6,11 @@
 		border-collapse: collapse;
 	}
 
-	thead {
-		th:last-of-type {
-			width: 60%;
-			padding-left: 1rem;
-		}
-	}
-
 	tbody {
 		background-color: $white;
 
 		@include respond-at("lg") {
 			box-shadow: $shadow-24-black-08;
-		}
-	}
-
-	tr {
-		td {
-			padding: $spacer-sm;
-		}
-
-		td:first-child {
-			padding-right: 0;
-		}
-
-		td:last-child {
-			padding-left: 0;
-		}
-
-		&:not(:last-of-type) {
-			border-bottom: 0.1rem solid $silver;
 		}
 	}
 


### PR DESCRIPTION
https://meemoo.atlassian.net/wiki/spaces/HA2/pages/4212817944/TA+meertaligheid#admin-core-UI-Voorzie-de-admin-core-ui-translations-op-meerdere-talen

translations correctly load on the client side
and the editor looks good:
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/ba201585-f31a-4f06-88b4-d27303ee573c)

![image](https://github.com/viaacode/hetarchief-client/assets/1710840/b1aef209-64c7-4494-92a7-9d3cd4bd52bd)
