### PR TITLE
feat(ARC-2197): enable server side rendering on the search page

### DIFF
--- a/src/modules/account/views/MyHistory.tsx
+++ b/src/modules/account/views/MyHistory.tsx
@@ -28,7 +28,7 @@ import { toastService } from '@shared/services/toast-service';
 import { AccessStatus, Visit } from '@shared/types';
 import { DefaultSeoInfo } from '@shared/types/seo';
 import { createVisitorSpacesWithFilterUrl } from '@shared/utils';
-import { VisitorSpaceFilterId } from '@visitor-space/types';
+import { SearchFilterId } from '@visitor-space/types';
 
 export const AccountMyHistory: FC<DefaultSeoInfo> = ({ url }) => {
 	const { tHtml, tText } = useTranslation();
@@ -95,7 +95,7 @@ export const AccountMyHistory: FC<DefaultSeoInfo> = ({ url }) => {
 			switch (response?.status) {
 				case AccessStatus.ACCESS:
 					router.push(
-						`${ROUTES_BY_LOCALE[locale].search}?${VisitorSpaceFilterId.Maintainer}=${visit.spaceSlug}`
+						`${ROUTES_BY_LOCALE[locale].search}?${SearchFilterId.Maintainer}=${visit.spaceSlug}`
 					);
 					break;
 				case AccessStatus.PENDING:

--- a/src/modules/account/views/MyProfile.tsx
+++ b/src/modules/account/views/MyProfile.tsx
@@ -329,7 +329,7 @@ export const AccountMyProfile: NextPage<DefaultSeoInfo> = ({ url }) => {
 	);
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/modules/auth/services/auth-service/auth.service.ts
+++ b/src/modules/auth/services/auth-service/auth.service.ts
@@ -9,7 +9,7 @@ import { ROUTE_PARTS_BY_LOCALE, ROUTES_BY_LOCALE } from '@shared/const';
 import { QUERY_PARAM_KEY } from '@shared/const/query-param-keys';
 import { ApiService } from '@shared/services/api-service';
 import { isBrowser, Locale } from '@shared/utils';
-import { VisitorSpaceFilterId } from '@visitor-space/types';
+import { SearchFilterId } from '@visitor-space/types';
 
 import { CheckLoginResponse } from './auth.service.types';
 
@@ -36,7 +36,7 @@ export class AuthService {
 		// Redirect /slug to the search page with filter
 		if (slug && !ie) {
 			// TODO split backend filter names (VisitorSpaceFilterId) from filter names in the url (create a new enum for those)
-			originalPath = `/${ROUTE_PARTS.search}?${VisitorSpaceFilterId.Maintainer}=${slug}`;
+			originalPath = `/${ROUTE_PARTS.search}?${SearchFilterId.Maintainer}=${slug}`;
 		}
 		if (
 			(originalPath || '') === ROUTES_BY_LOCALE[(router.locale || Locale.nl) as Locale].home

--- a/src/modules/cp/layouts/CPAdminLayout/CPAdminLayout.tsx
+++ b/src/modules/cp/layouts/CPAdminLayout/CPAdminLayout.tsx
@@ -16,7 +16,7 @@ import { useLocale } from '@shared/hooks/use-locale/use-locale';
 import useTranslation from '@shared/hooks/use-translation/use-translation';
 import SidebarLayout from '@shared/layouts/SidebarLayout/SidebarLayout';
 import { setShowZendesk } from '@shared/store/ui';
-import { VisitorSpaceFilterId } from '@visitor-space/types';
+import { SearchFilterId } from '@visitor-space/types';
 
 import styles from './CPAdminLayout.module.scss';
 
@@ -37,7 +37,7 @@ const CPAdminLayout: FC<CPAdminLayoutProps> = ({ children, className, pageTitle 
 						: stringifyUrl({
 								url: href,
 								query: {
-									[VisitorSpaceFilterId.Maintainer]: user?.visitorSpaceSlug,
+									[SearchFilterId.Maintainer]: user?.visitorSpaceSlug,
 								},
 						  });
 

--- a/src/modules/i18n/helpers/get-translations.ts
+++ b/src/modules/i18n/helpers/get-translations.ts
@@ -14,6 +14,6 @@ export async function getTranslations(locale: Locale): Promise<Record<string, st
 				en: 'admin/translations/en.json',
 			},
 		});
-		return {};
+		return Promise.resolve({});
 	}
 }

--- a/src/modules/ie-objects/hooks/get-ie-object-format-counts.ts
+++ b/src/modules/ie-objects/hooks/get-ie-object-format-counts.ts
@@ -5,7 +5,7 @@ import { QUERY_KEYS } from '@shared/const/query-keys';
 import {
 	IeObjectsSearchFilter,
 	IeObjectsSearchFilterField,
-	VisitorSpaceMediaType,
+	SearchPageMediaType,
 } from '@shared/types';
 import { ElasticsearchFieldNames } from '@visitor-space/types';
 
@@ -14,7 +14,7 @@ import { IeObjectsService } from './../services';
 export const useGetIeObjectFormatCounts = (
 	filters: IeObjectsSearchFilter[],
 	options: { enabled: boolean } = { enabled: true }
-): UseQueryResult<Record<VisitorSpaceMediaType, number>> => {
+): UseQueryResult<Record<SearchPageMediaType, number>> => {
 	return useQuery(
 		[QUERY_KEYS.getIeObjectFormatCounts, filters, options],
 		async () => {
@@ -26,7 +26,7 @@ export const useGetIeObjectFormatCounts = (
 
 			return Object.fromEntries(
 				results.aggregations[ElasticsearchFieldNames.Format].buckets.map((bucket) => [
-					bucket.key as VisitorSpaceMediaType,
+					bucket.key as SearchPageMediaType,
 					bucket.doc_count,
 				])
 			);

--- a/src/modules/ie-objects/services/ie-objects/ie-objects.service.ts
+++ b/src/modules/ie-objects/services/ie-objects/ie-objects.service.ts
@@ -8,11 +8,11 @@ import {
 	IeObjectsSearchFilter,
 	IeObjectsSearchFilterField,
 	IeObjectsSearchOperator,
+	SearchPageMediaType,
 	SortObject,
-	VisitorSpaceMediaType,
 } from '@shared/types';
 import { GetIeObjectsResponse } from '@shared/types/api';
-import { VisitorSpaceSort } from '@visitor-space/types';
+import { SearchSortProp } from '@visitor-space/types';
 
 import {
 	IE_OBJECT_SERVICE_SEO_URL,
@@ -32,7 +32,7 @@ export class IeObjectsService {
 		sort?: SortObject,
 		requestedAggs?: IeObjectsSearchFilterField[]
 	): Promise<GetIeObjectsResponse> {
-		const parsedSort = !sort || sort.orderProp === VisitorSpaceSort.Relevance ? {} : sort;
+		const parsedSort = !sort || sort.orderProp === SearchSortProp.Relevance ? {} : sort;
 		const filtered = [
 			...filters.filter((item) => {
 				// Don't send filters with no value(s)
@@ -46,7 +46,7 @@ export class IeObjectsService {
 				const isFormatAllFilter =
 					item.field === IeObjectsSearchFilterField.FORMAT &&
 					item.operator === IeObjectsSearchOperator.IS &&
-					item.value === VisitorSpaceMediaType.All;
+					item.value === SearchPageMediaType.All;
 
 				return hasValue && hasLength && !isFormatAllFilter;
 			}),

--- a/src/modules/ie-objects/utils/map-metadata/map-metadata.tsx
+++ b/src/modules/ie-objects/utils/map-metadata/map-metadata.tsx
@@ -9,7 +9,7 @@ import { ROUTE_PARTS_BY_LOCALE } from '@shared/const';
 import { QUERY_PARAM_KEY } from '@shared/const/query-param-keys';
 import { tText } from '@shared/helpers/translate';
 import { Locale } from '@shared/utils';
-import { VisitorSpaceFilterId } from '@visitor-space/types';
+import { SearchFilterId } from '@visitor-space/types';
 
 export const mapKeywordsToTags = (keywords: string[]): TagOption[] => {
 	return keywords.map((item) => {
@@ -34,7 +34,7 @@ export const renderKeywordsAsTags = (
 					stringifyUrl({
 						url: `/${ROUTE_PARTS_BY_LOCALE[locale].search}`,
 						query: {
-							[VisitorSpaceFilterId.Maintainer]: slug,
+							[SearchFilterId.Maintainer]: slug,
 							[QUERY_PARAM_KEY.SEARCH_QUERY_KEY]: keyword,
 						},
 					})

--- a/src/modules/navigation/components/Navigation/Navigation.consts.tsx
+++ b/src/modules/navigation/components/Navigation/Navigation.consts.tsx
@@ -21,7 +21,7 @@ import {
 import { tText } from '@shared/helpers/translate';
 import { Breakpoints, Visit } from '@shared/types';
 import { Locale } from '@shared/utils';
-import { VisitorSpaceFilterId, VisitorSpaceInfo } from '@visitor-space/types';
+import { SearchFilterId, VisitorSpaceInfo } from '@visitor-space/types';
 
 const linkCls = (...classNames: string[]) => {
 	return clsx(styles['c-navigation__link'], ...classNames);
@@ -109,7 +109,7 @@ const getVisitorSpacesDropdown = (
 	const visitPath = ROUTES_BY_LOCALE[locale].visit;
 	if (linkedSpaceOrId) {
 		// Single link to go to linked visitor space (kiosk visitor)
-		const searchRouteForSpace = `/${ROUTE_PARTS_BY_LOCALE[locale].search}?${VisitorSpaceFilterId.Maintainer}=${linkedSpaceOrId}`;
+		const searchRouteForSpace = `/${ROUTE_PARTS_BY_LOCALE[locale].search}?${SearchFilterId.Maintainer}=${linkedSpaceOrId}`;
 		return {
 			node: renderLink(
 				tText('modules/navigation/components/navigation/navigation___bezoekersruimte'),
@@ -168,7 +168,7 @@ const getVisitorSpacesDropdown = (
 					isDivider: accessibleVisitorSpaces.length > 0 ? 'md' : undefined,
 				},
 				...accessibleVisitorSpaces.map((visitorSpace: VisitorSpaceInfo): NavigationItem => {
-					const searchRouteForSpace = `/${ROUTE_PARTS_BY_LOCALE[locale].search}?${VisitorSpaceFilterId.Maintainer}=${visitorSpace.slug}`;
+					const searchRouteForSpace = `/${ROUTE_PARTS_BY_LOCALE[locale].search}?${SearchFilterId.Maintainer}=${visitorSpace.slug}`;
 					return {
 						node: ({ closeDropdowns }) =>
 							renderLink(
@@ -393,7 +393,7 @@ const getCpAdminManagementDropdown = (
 									stringifyUrl({
 										url: `/${ROUTE_PARTS_BY_LOCALE[locale].search}`,
 										query: {
-											[VisitorSpaceFilterId.Maintainer]: maintainerSlug,
+											[SearchFilterId.Maintainer]: maintainerSlug,
 										},
 									}),
 									{

--- a/src/modules/search/MaintainerSearchPage.tsx
+++ b/src/modules/search/MaintainerSearchPage.tsx
@@ -9,7 +9,7 @@ import { ROUTE_PARTS_BY_LOCALE } from '@shared/const';
 import { useLocale } from '@shared/hooks/use-locale/use-locale';
 import { DefaultSeoInfo } from '@shared/types/seo';
 import { useGetOrganisationBySlug } from '@visitor-space/hooks/get-organisation-by-slug';
-import { FILTER_LABEL_VALUE_DELIMITER, VisitorSpaceFilterId } from '@visitor-space/types';
+import { FILTER_LABEL_VALUE_DELIMITER, SearchFilterId } from '@visitor-space/types';
 
 type MaintainerSearchPageProps = DefaultSeoInfo;
 
@@ -35,7 +35,7 @@ export const MaintainerSearchPage: FC<MaintainerSearchPageProps> = () => {
 			const searchUrl = stringifyUrl({
 				url: `/${ROUTE_PARTS_BY_LOCALE[locale].search}`,
 				query: {
-					[VisitorSpaceFilterId.Maintainers]: `${organisation.schemaIdentifier}${FILTER_LABEL_VALUE_DELIMITER}${organisation.schemaName}`,
+					[SearchFilterId.Maintainers]: `${organisation.schemaIdentifier}${FILTER_LABEL_VALUE_DELIMITER}${organisation.schemaName}`,
 				},
 			});
 			router.replace(searchUrl, undefined, { shallow: true });

--- a/src/modules/search/ObjectDetailPage.tsx
+++ b/src/modules/search/ObjectDetailPage.tsx
@@ -130,7 +130,7 @@ import { EventsService, LogEventType } from '@shared/services/events-service';
 import { toastService } from '@shared/services/toast-service';
 import { selectFolders } from '@shared/store/ie-objects';
 import { selectBreadcrumbs, setShowAuthModal, setShowZendesk } from '@shared/store/ui';
-import { Breakpoints, IeObjectTypes, VisitorSpaceMediaType } from '@shared/types';
+import { Breakpoints, IeObjectTypes, SearchPageMediaType } from '@shared/types';
 import { DefaultSeoInfo } from '@shared/types/seo';
 import {
 	asDate,
@@ -148,7 +148,7 @@ import { ReportBlade } from '@visitor-space/components/reportBlade';
 import { useGetVisitorSpace } from '@visitor-space/hooks/get-visitor-space';
 import {
 	FILTER_LABEL_VALUE_DELIMITER,
-	VisitorSpaceFilterId,
+	SearchFilterId,
 	VisitorSpaceStatus,
 } from '@visitor-space/types';
 
@@ -390,7 +390,7 @@ export const ObjectDetailPage: FC<ObjectDetailPageProps> = ({ title, description
 		setMediaType(mediaInfo?.dctermsFormat as IeObjectTypes);
 
 		// Filter out peak files if type === video
-		if (mediaInfo?.dctermsFormat === VisitorSpaceMediaType.Video) {
+		if (mediaInfo?.dctermsFormat === SearchPageMediaType.Video) {
 			mediaInfo.representations = mediaInfo?.representations?.filter(
 				(object) => object.dctermsFormat !== 'peak'
 			);
@@ -1030,7 +1030,7 @@ export const ObjectDetailPage: FC<ObjectDetailPageProps> = ({ title, description
 									label: mediaInfo?.maintainerName,
 									to: isKiosk
 										? ROUTES_BY_LOCALE[locale].search
-										: `${ROUTES_BY_LOCALE[locale].search}?${VisitorSpaceFilterId.Maintainer}=${mediaInfo?.maintainerSlug}`,
+										: `${ROUTES_BY_LOCALE[locale].search}?${SearchFilterId.Maintainer}=${mediaInfo?.maintainerSlug}`,
 								},
 						  ]
 						: []),
@@ -1125,7 +1125,7 @@ export const ObjectDetailPage: FC<ObjectDetailPageProps> = ({ title, description
 									stringifyUrl({
 										url: ROUTES_BY_LOCALE[locale].search,
 										query: {
-											[VisitorSpaceFilterId.Maintainers]: [
+											[SearchFilterId.Maintainers]: [
 												`${maintainerId}${FILTER_LABEL_VALUE_DELIMITER}${maintainerName}`,
 											],
 										},

--- a/src/modules/shared/components/MediaCardList/MediaCardList.const.ts
+++ b/src/modules/shared/components/MediaCardList/MediaCardList.const.ts
@@ -1,5 +1,5 @@
 import { Breakpoints } from '@shared/types';
-import { VISITOR_SPACE_ITEM_COUNT } from '@visitor-space/const';
+import { SEARCH_RESULTS_PAGE_SIZE } from '@visitor-space/const';
 
 export const MEDIA_CARD_LIST_GRID_BP_COLS = {
 	default: 4,
@@ -10,5 +10,5 @@ export const MEDIA_CARD_LIST_GRID_BP_COLS = {
 
 export const MAX_COUNT_SEARCH_RESULTS = 10000;
 export const PAGE_NUMBER_OF_MANY_RESULTS_TILE = Math.ceil(
-	MAX_COUNT_SEARCH_RESULTS / VISITOR_SPACE_ITEM_COUNT
+	MAX_COUNT_SEARCH_RESULTS / SEARCH_RESULTS_PAGE_SIZE
 );

--- a/src/modules/shared/components/Tabs/__mocks__/tabs.tsx
+++ b/src/modules/shared/components/Tabs/__mocks__/tabs.tsx
@@ -1,9 +1,9 @@
 import { Icon, IconNamesLight } from '@shared/components';
-import { VisitorSpaceMediaType } from '@shared/types';
+import { SearchPageMediaType } from '@shared/types';
 
 export const mockTabs = [
 	{
-		id: VisitorSpaceMediaType.All,
+		id: SearchPageMediaType.All,
 		label: (
 			<>
 				<strong className="u-mr-8">Alles</strong>
@@ -13,7 +13,7 @@ export const mockTabs = [
 		active: true,
 	},
 	{
-		id: VisitorSpaceMediaType.Audio,
+		id: SearchPageMediaType.Audio,
 		label: (
 			<>
 				<strong className="u-mr-8">Audio</strong>
@@ -23,7 +23,7 @@ export const mockTabs = [
 		icon: <Icon name={IconNamesLight.Audio} />,
 	},
 	{
-		id: VisitorSpaceMediaType.Video,
+		id: SearchPageMediaType.Video,
 		label: (
 			<>
 				<strong className="u-mr-8">Video</strong>

--- a/src/modules/shared/helpers/get-default-server-side-props.ts
+++ b/src/modules/shared/helpers/get-default-server-side-props.ts
@@ -1,6 +1,6 @@
-import { GetServerSidePropsResult } from 'next';
+import { DehydratedState } from '@tanstack/react-query';
 import getConfig from 'next/config';
-import { GetServerSidePropsContext } from 'next/types';
+import { GetServerSidePropsContext, GetServerSidePropsResult } from 'next/types';
 import { i18n } from 'next-i18next';
 
 import { getTranslations } from '@i18n/helpers/get-translations';
@@ -10,7 +10,11 @@ import { isBrowser, Locale } from '@shared/utils';
 const { publicRuntimeConfig } = getConfig();
 
 export async function getDefaultStaticProps(
-	context: GetServerSidePropsContext
+	context: GetServerSidePropsContext,
+	dehydratedState?: DehydratedState,
+	title?: string | null,
+	description?: string | null,
+	image?: string | null
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	const locale = (context.locale || Locale.nl) as Locale;
 	const translations = await getTranslations(locale);
@@ -20,6 +24,10 @@ export async function getDefaultStaticProps(
 			url:
 				(isBrowser() ? publicRuntimeConfig.CLIENT_URL : process.env.CLIENT_URL) +
 				(context?.resolvedUrl || ''),
+			title: title || null,
+			description: description || null,
+			image: image || null,
+			dehydratedState,
 			_nextI18Next: {
 				initialI18nStore: {
 					[locale]: {

--- a/src/modules/shared/services/notifications-service/notifications.consts.ts
+++ b/src/modules/shared/services/notifications-service/notifications.consts.ts
@@ -2,7 +2,7 @@ import { VISIT_REQUEST_ID_QUERY_KEY } from '@cp/const/requests.const';
 import { ROUTE_PARTS_BY_LOCALE, ROUTES_BY_LOCALE } from '@shared/const';
 import { NotificationType } from '@shared/services/notifications-service/notifications.types';
 import { Locale } from '@shared/utils';
-import { VisitorSpaceFilterId } from '@visitor-space/types';
+import { SearchFilterId } from '@visitor-space/types';
 
 export const GET_PATH_FROM_NOTIFICATION_TYPE = (
 	locale: Locale
@@ -14,7 +14,7 @@ export const GET_PATH_FROM_NOTIFICATION_TYPE = (
 		[NotificationType.VISIT_REQUEST_CANCELLED]: null,
 
 		// Absolute url, so we force reload the page, so the active visitor spaces are reloaded
-		[NotificationType.ACCESS_PERIOD_VISITOR_SPACE_STARTED]: `${window.location.origin}/${ROUTE_PARTS_BY_LOCALE[locale].search}?${VisitorSpaceFilterId.Maintainer}={slug}`,
+		[NotificationType.ACCESS_PERIOD_VISITOR_SPACE_STARTED]: `${window.location.origin}/${ROUTE_PARTS_BY_LOCALE[locale].search}?${SearchFilterId.Maintainer}={slug}`,
 		[NotificationType.ACCESS_PERIOD_VISITOR_SPACE_END_WARNING]: null,
 		[NotificationType.ACCESS_PERIOD_VISITOR_SPACE_ENDED]:
 			ROUTES_BY_LOCALE[locale].accountMyVisitHistory,

--- a/src/modules/shared/types/ie-objects.ts
+++ b/src/modules/shared/types/ie-objects.ts
@@ -1,6 +1,6 @@
 export type IeObjectTypes = 'video' | 'audio' | 'film' | null;
 
-export enum VisitorSpaceMediaType {
+export enum SearchPageMediaType {
 	All = 'all',
 	Audio = 'audio',
 	Video = 'video',

--- a/src/modules/shared/types/seo.ts
+++ b/src/modules/shared/types/seo.ts
@@ -2,6 +2,9 @@ import { DehydratedState } from '@tanstack/react-query';
 
 export interface DefaultSeoInfo {
 	url: string;
+	title?: string | null;
+	description?: string | null;
+	image?: string | null;
 	dehydratedState?: DehydratedState;
 	_nextI18Next?: {
 		initialI18nStore: {

--- a/src/modules/visitor-space/components/AdvancedFilterForm/AdvancedFilterForm.tsx
+++ b/src/modules/visitor-space/components/AdvancedFilterForm/AdvancedFilterForm.tsx
@@ -7,7 +7,7 @@ import { useFieldArray, useForm } from 'react-hook-form';
 import { Icon, IconNamesLight } from '@shared/components';
 import useTranslation from '@shared/hooks/use-translation/use-translation';
 
-import { VisitorSpaceFilterId } from '../../types';
+import { SearchFilterId } from '../../types';
 import { AdvancedFilterFields } from '../AdvancedFilterFields';
 
 import { ADVANCED_FILTER_FORM_SCHEMA, initialFields } from './AdvancedFilterForm.const';
@@ -28,7 +28,7 @@ const AdvancedFilterForm: FC<AdvancedFilterFormProps> = ({
 		resolver: yupResolver(ADVANCED_FILTER_FORM_SCHEMA()),
 	});
 	const { append, fields, remove, update } = useFieldArray({
-		name: VisitorSpaceFilterId.Advanced,
+		name: SearchFilterId.Advanced,
 		control,
 	});
 

--- a/src/modules/visitor-space/components/ConsultableMediaFilterForm/ConsultableMediaFilterForm.const.ts
+++ b/src/modules/visitor-space/components/ConsultableMediaFilterForm/ConsultableMediaFilterForm.const.ts
@@ -3,7 +3,7 @@ import { boolean, object, SchemaOf } from 'yup';
 
 import { IeObjectsSearchFilterField } from '@shared/types';
 
-import { VisitorSpaceFilterId } from '../../types';
+import { SearchFilterId } from '../../types';
 
 import { ConsultableMediaFilterFormState } from './ConsultableMediaFilterForm.types';
 
@@ -13,5 +13,5 @@ export const CONSULTABLE_MEDIA_FILTER_FORM_SCHEMA = (): SchemaOf<ConsultableMedi
 	});
 
 export const CONSULTABLE_MEDIA_FILTER_FORM_QUERY_PARAM_CONFIG = {
-	[VisitorSpaceFilterId.ConsultableMedia]: BooleanParam,
+	[SearchFilterId.ConsultableMedia]: BooleanParam,
 };

--- a/src/modules/visitor-space/components/ConsultableMediaFilterForm/ConsultableMediaFilterForm.tsx
+++ b/src/modules/visitor-space/components/ConsultableMediaFilterForm/ConsultableMediaFilterForm.tsx
@@ -7,7 +7,7 @@ import { useQueryParams } from 'use-query-params';
 
 import { Icon, IconNamesLight } from '@shared/components';
 import { IeObjectsSearchFilterField } from '@shared/types';
-import { VisitorSpaceFilterId } from '@visitor-space/types';
+import { SearchFilterId } from '@visitor-space/types';
 
 import {
 	CONSULTABLE_MEDIA_FILTER_FORM_QUERY_PARAM_CONFIG,
@@ -31,7 +31,7 @@ const ConsultableMediaFilterForm: FC<ConsultableMediaFilterFormProps> = ({
 	const [isInitialRender, setIsInitialRender] = useState(true);
 	const [query] = useQueryParams(CONSULTABLE_MEDIA_FILTER_FORM_QUERY_PARAM_CONFIG);
 	const [isChecked, setIsChecked] = useState<boolean>(
-		() => query[VisitorSpaceFilterId.ConsultableMedia] || false
+		() => query[SearchFilterId.ConsultableMedia] || false
 	);
 
 	const { setValue, handleSubmit } = useForm<ConsultableMediaFilterFormState>({
@@ -40,7 +40,7 @@ const ConsultableMediaFilterForm: FC<ConsultableMediaFilterFormProps> = ({
 	});
 
 	const onFilterFormSubmit = useCallback(
-		(id: VisitorSpaceFilterId, values: unknown) => onFormSubmit(id, values),
+		(id: SearchFilterId, values: unknown) => onFormSubmit(id, values),
 		[onFormSubmit]
 	);
 

--- a/src/modules/visitor-space/components/ConsultableOnlyOnLocationFilterForm/ConsultableOnlyOnLocationFilterForm.const.ts
+++ b/src/modules/visitor-space/components/ConsultableOnlyOnLocationFilterForm/ConsultableOnlyOnLocationFilterForm.const.ts
@@ -4,7 +4,7 @@ import { boolean, object, SchemaOf } from 'yup';
 import { IeObjectsSearchFilterField } from '@shared/types';
 import { ConsultableOnlyOnLocationFilterFormState } from '@visitor-space/components';
 
-import { VisitorSpaceFilterId } from '../../types';
+import { SearchFilterId } from '../../types';
 
 export const CONSULTABLE_ONLY_ON_LOCATION_FILTER_FORM_SCHEMA =
 	(): SchemaOf<ConsultableOnlyOnLocationFilterFormState> =>
@@ -13,5 +13,5 @@ export const CONSULTABLE_ONLY_ON_LOCATION_FILTER_FORM_SCHEMA =
 		});
 
 export const REMOTE_FILTER_FORM_QUERY_PARAM_CONFIG = {
-	[VisitorSpaceFilterId.ConsultableOnlyOnLocation]: BooleanParam,
+	[SearchFilterId.ConsultableOnlyOnLocation]: BooleanParam,
 };

--- a/src/modules/visitor-space/components/ConsultableOnlyOnLocationFilterForm/ConsultableOnlyOnLocationFilterForm.tsx
+++ b/src/modules/visitor-space/components/ConsultableOnlyOnLocationFilterForm/ConsultableOnlyOnLocationFilterForm.tsx
@@ -11,7 +11,7 @@ import {
 	ConsultableOnlyOnLocationFilterFormProps,
 	ConsultableOnlyOnLocationFilterFormState,
 } from '@visitor-space/components';
-import { VisitorSpaceFilterId } from '@visitor-space/types';
+import { SearchFilterId } from '@visitor-space/types';
 
 import {
 	CONSULTABLE_ONLY_ON_LOCATION_FILTER_FORM_SCHEMA,
@@ -31,7 +31,7 @@ const ConsultableOnlyOnLocationFilterForm: FC<ConsultableOnlyOnLocationFilterFor
 	const [isInitialRender, setIsInitialRender] = useState(true);
 	const [query] = useQueryParams(REMOTE_FILTER_FORM_QUERY_PARAM_CONFIG);
 	const [isChecked, setIsChecked] = useState<boolean>(
-		() => query[VisitorSpaceFilterId.ConsultableOnlyOnLocation] || false
+		() => query[SearchFilterId.ConsultableOnlyOnLocation] || false
 	);
 
 	const { setValue, handleSubmit } = useForm<ConsultableOnlyOnLocationFilterFormState>({
@@ -40,7 +40,7 @@ const ConsultableOnlyOnLocationFilterForm: FC<ConsultableOnlyOnLocationFilterFor
 	});
 
 	const onFilterFormSubmit = useCallback(
-		(id: VisitorSpaceFilterId, values: unknown) => onFormSubmit(id, values),
+		(id: SearchFilterId, values: unknown) => onFormSubmit(id, values),
 		[onFormSubmit]
 	);
 

--- a/src/modules/visitor-space/components/CreatedFilterForm/CreatedFilterForm.const.ts
+++ b/src/modules/visitor-space/components/CreatedFilterForm/CreatedFilterForm.const.ts
@@ -3,7 +3,7 @@ import { mixed, object, SchemaOf, string } from 'yup';
 import { Operator } from '@shared/types';
 
 import { AdvancedFilterArrayParam } from '../../const/query-params';
-import { VisitorSpaceFilterId } from '../../types';
+import { SearchFilterId } from '../../types';
 
 import { CreatedFilterFormState } from './CreatedFilterForm.types';
 
@@ -14,5 +14,5 @@ export const CREATED_FILTER_FORM_SCHEMA = (): SchemaOf<CreatedFilterFormState> =
 	});
 
 export const CREATED_FILTER_FORM_QUERY_PARAM_CONFIG = {
-	[VisitorSpaceFilterId.Created]: AdvancedFilterArrayParam,
+	[SearchFilterId.Created]: AdvancedFilterArrayParam,
 };

--- a/src/modules/visitor-space/components/CreatorFilterForm/CreatorFilterForm.const.ts
+++ b/src/modules/visitor-space/components/CreatorFilterForm/CreatorFilterForm.const.ts
@@ -1,7 +1,7 @@
 import { StringParam } from 'use-query-params';
 import { object, SchemaOf, string } from 'yup';
 
-import { VisitorSpaceFilterId } from '@visitor-space/types';
+import { SearchFilterId } from '@visitor-space/types';
 
 import { CreatorFilterFormState } from './CreatorFilterForm.types';
 
@@ -11,5 +11,5 @@ export const CREATOR_FILTER_FORM_SCHEMA = (): SchemaOf<CreatorFilterFormState> =
 	});
 
 export const CREATOR_FILTER_FORM_QUERY_PARAM_CONFIG = {
-	[VisitorSpaceFilterId.Creator]: StringParam,
+	[SearchFilterId.Creator]: StringParam,
 };

--- a/src/modules/visitor-space/components/CreatorFilterForm/CreatorFilterForm.tsx
+++ b/src/modules/visitor-space/components/CreatorFilterForm/CreatorFilterForm.tsx
@@ -8,7 +8,7 @@ import { useQueryParams } from 'use-query-params';
 
 import useTranslation from '@shared/hooks/use-translation/use-translation';
 import { CREATOR_FILTER_FORM_SCHEMA, CreatorFilterFormState } from '@visitor-space/components';
-import { VisitorSpaceFilterId } from '@visitor-space/types';
+import { SearchFilterId } from '@visitor-space/types';
 
 import { CREATOR_FILTER_FORM_QUERY_PARAM_CONFIG } from './CreatorFilterForm.const';
 import styles from './CreatorFilterForm.module.scss';
@@ -24,7 +24,7 @@ const CreatorFilterForm: FC<CreatorFilterFormProps> = ({ children, className }) 
 	// State
 	const [query] = useQueryParams(CREATOR_FILTER_FORM_QUERY_PARAM_CONFIG);
 
-	const initial = query?.[VisitorSpaceFilterId.Creator] || '';
+	const initial = query?.[SearchFilterId.Creator] || '';
 
 	const [form, setForm] = useState<CreatorFilterFormState>({ creator: initial });
 	const {

--- a/src/modules/visitor-space/components/DurationFilterForm/DurationFilterForm.const.ts
+++ b/src/modules/visitor-space/components/DurationFilterForm/DurationFilterForm.const.ts
@@ -6,7 +6,7 @@ import { Operator } from '@shared/types';
 
 import { durationRegex } from '../../components/DurationInput/DurationInput.consts';
 import { AdvancedFilterArrayParam } from '../../const/query-params';
-import { VisitorSpaceFilterId } from '../../types';
+import { SearchFilterId } from '../../types';
 
 import { DurationFilterFormState } from './DurationFilterForm.types';
 
@@ -28,5 +28,5 @@ export const DURATION_FILTER_FORM_SCHEMA = (): SchemaOf<DurationFilterFormState>
 	});
 
 export const DURATION_FILTER_FORM_QUERY_PARAM_CONFIG = {
-	[VisitorSpaceFilterId.Duration]: AdvancedFilterArrayParam,
+	[SearchFilterId.Duration]: AdvancedFilterArrayParam,
 };

--- a/src/modules/visitor-space/components/FilterMenu/FilterForm/FilterForm.const.ts
+++ b/src/modules/visitor-space/components/FilterMenu/FilterForm/FilterForm.const.ts
@@ -1,3 +1,3 @@
-import { VisitorSpaceFilterId } from '@visitor-space/types';
+import { SearchFilterId } from '@visitor-space/types';
 
-export const HAS_SHOW_OVERFLOW: VisitorSpaceFilterId[] = [VisitorSpaceFilterId.Duration];
+export const HAS_SHOW_OVERFLOW: SearchFilterId[] = [SearchFilterId.Duration];

--- a/src/modules/visitor-space/components/FilterMenu/FilterForm/FilterForm.tsx
+++ b/src/modules/visitor-space/components/FilterMenu/FilterForm/FilterForm.tsx
@@ -8,7 +8,7 @@ import { visitorSpaceLabelKeys } from '@visitor-space/const';
 import {
 	DefaultFilterFormProps,
 	InlineFilterFormProps,
-	VisitorSpaceFilterId,
+	SearchFilterId,
 } from '@visitor-space/types';
 
 import { FilterMenuType } from '../FilterMenu.types';
@@ -30,17 +30,17 @@ const FilterForm: FC<FilterFormProps> = ({
 }) => {
 	const { tHtml } = useTranslation();
 
-	const onFilterFormReset = (id: VisitorSpaceFilterId, reset: () => void) => {
+	const onFilterFormReset = (id: SearchFilterId, reset: () => void) => {
 		reset();
 		onFormReset(id);
 	};
 
-	const onFilterFormSubmit = (id: VisitorSpaceFilterId, values: unknown) => {
+	const onFilterFormSubmit = (id: SearchFilterId, values: unknown) => {
 		onFormSubmit(id, values);
 	};
 
 	const showOverflow = useMemo(
-		(): boolean => HAS_SHOW_OVERFLOW.includes(id as VisitorSpaceFilterId),
+		(): boolean => HAS_SHOW_OVERFLOW.includes(id as SearchFilterId),
 		[id]
 	);
 

--- a/src/modules/visitor-space/components/FilterMenu/FilterForm/FilterForm.types.ts
+++ b/src/modules/visitor-space/components/FilterMenu/FilterForm/FilterForm.types.ts
@@ -2,17 +2,13 @@ import { FC } from 'react';
 
 import { DefaultComponentProps } from '@shared/types';
 
-import {
-	DefaultFilterFormProps,
-	InlineFilterFormProps,
-	VisitorSpaceFilterId,
-} from '../../../types';
+import { DefaultFilterFormProps, InlineFilterFormProps, SearchFilterId } from '../../../types';
 import { FilterMenuType, OnFilterMenuFormReset, OnFilterMenuFormSubmit } from '../FilterMenu.types';
 
 export interface FilterFormProps extends DefaultComponentProps {
 	children?: React.ReactNode;
 	form: FC<DefaultFilterFormProps<any>> | FC<InlineFilterFormProps> | null;
-	id: VisitorSpaceFilterId;
+	id: SearchFilterId;
 	onFormReset: OnFilterMenuFormReset;
 	onFormSubmit: OnFilterMenuFormSubmit;
 	title: string;

--- a/src/modules/visitor-space/components/FilterMenu/FilterMenu.tsx
+++ b/src/modules/visitor-space/components/FilterMenu/FilterMenu.tsx
@@ -9,9 +9,10 @@ import { tText } from '@shared/helpers/translate';
 import { useScrollLock } from '@shared/hooks/use-scroll-lock';
 import { useWindowSizeContext } from '@shared/hooks/use-window-size-context';
 import { Breakpoints } from '@shared/types';
+import { isServerSideRendering } from '@shared/utils';
 
-import { VISITOR_SPACE_ACTIVE_SORT_MAP, VISITOR_SPACE_QUERY_PARAM_CONFIG } from '../../const';
-import { VisitorSpaceFilterId, VisitorSpaceSort } from '../../types';
+import { SEARCH_PAGE_QUERY_PARAM_CONFIG, VISITOR_SPACE_ACTIVE_SORT_MAP } from '../../const';
+import { SearchFilterId, SearchSortProp } from '../../types';
 
 import styles from './FilterMenu.module.scss';
 import { FilterMenuFilterOption, FilterMenuProps } from './FilterMenu.types';
@@ -36,7 +37,7 @@ const FilterMenu: FC<FilterMenuProps> = ({
 	onViewToggle = () => null,
 	onRemoveValue,
 }) => {
-	const [query, setQuery] = useQueryParams(VISITOR_SPACE_QUERY_PARAM_CONFIG);
+	const [query, setQuery] = useQueryParams(SEARCH_PAGE_QUERY_PARAM_CONFIG);
 
 	const [lockScroll, setLockScroll] = useState<boolean>(false);
 	// We need different functionalities for different viewport sizes
@@ -69,11 +70,11 @@ const FilterMenu: FC<FilterMenuProps> = ({
 		setQuery({ filter });
 	};
 
-	const onFilterFormReset = (id: VisitorSpaceFilterId) => {
+	const onFilterFormReset = (id: SearchFilterId) => {
 		onFilterReset(id);
 	};
 
-	const onFilterFormSubmit = (id: VisitorSpaceFilterId, values: unknown) => {
+	const onFilterFormSubmit = (id: SearchFilterId, values: unknown) => {
 		onFilterSubmit(id, values);
 	};
 
@@ -95,7 +96,7 @@ const FilterMenu: FC<FilterMenuProps> = ({
 
 	const renderActiveSortLabel = () => {
 		const sortBtnLabel = activeSort
-			? VISITOR_SPACE_ACTIVE_SORT_MAP()[activeSort.orderProp as VisitorSpaceSort]
+			? VISITOR_SPACE_ACTIVE_SORT_MAP()[activeSort.orderProp as SearchSortProp]
 			: '';
 
 		return (
@@ -134,6 +135,12 @@ const FilterMenu: FC<FilterMenuProps> = ({
 				/>
 			)
 		);
+
+	if (isServerSideRendering()) {
+		// ReactSelect doesn't work with server side rendering
+		// React.jsx: type is invalid -- expected a string (for built-in components) or a class/function (for composite components) but got: object.
+		return null;
+	}
 
 	return (
 		<div className={clsx(className, styles['c-filter-menu'])}>

--- a/src/modules/visitor-space/components/FilterMenu/FilterMenu.types.ts
+++ b/src/modules/visitor-space/components/FilterMenu/FilterMenu.types.ts
@@ -7,9 +7,9 @@ import { DefaultComponentProps, SortObject } from '@shared/types';
 import {
 	DefaultFilterFormProps,
 	InlineFilterFormProps,
+	SearchFilterId,
+	SearchSortProp,
 	TagIdentity,
-	VisitorSpaceFilterId,
-	VisitorSpaceSort,
 } from '../../types';
 
 export interface FilterMenuProps extends DefaultComponentProps {
@@ -32,7 +32,7 @@ export interface FilterMenuProps extends DefaultComponentProps {
 
 export interface FilterMenuSortOption {
 	label: string;
-	orderProp: VisitorSpaceSort;
+	orderProp: SearchSortProp;
 	orderDirection?: OrderDirection;
 }
 
@@ -42,7 +42,7 @@ export enum FilterMenuType {
 }
 
 export interface FilterMenuFilterOption {
-	id: VisitorSpaceFilterId;
+	id: SearchFilterId;
 	icon?: IconName;
 	label: string;
 	form: FC<DefaultFilterFormProps<any>> | FC<InlineFilterFormProps<any>> | null; // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -50,6 +50,6 @@ export interface FilterMenuFilterOption {
 	isDisabled?: () => boolean;
 }
 
-export type OnFilterMenuSortClick = (key: VisitorSpaceSort, order?: OrderDirection) => void;
-export type OnFilterMenuFormSubmit = <Values>(id: VisitorSpaceFilterId, values: Values) => void;
-export type OnFilterMenuFormReset = (id: VisitorSpaceFilterId) => void;
+export type OnFilterMenuSortClick = (key: SearchSortProp, order?: OrderDirection) => void;
+export type OnFilterMenuFormSubmit = <Values>(id: SearchFilterId, values: Values) => void;
+export type OnFilterMenuFormReset = (id: SearchFilterId) => void;

--- a/src/modules/visitor-space/components/FilterMenu/FilterMenuMobile/FilterMenuMobile.tsx
+++ b/src/modules/visitor-space/components/FilterMenu/FilterMenuMobile/FilterMenuMobile.tsx
@@ -7,7 +7,7 @@ import { Navigation } from '@navigation/components';
 import { Icon, IconNamesLight } from '@shared/components';
 import useTranslation from '@shared/hooks/use-translation/use-translation';
 
-import { VisitorSpaceSort } from '../../../types';
+import { SearchSortProp } from '../../../types';
 import { mapFiltersToTags } from '../../../utils';
 import { FilterButton } from '../FilterButton';
 import FilterForm from '../FilterForm/FilterForm';
@@ -55,7 +55,7 @@ const FilterMenuMobile: FC<FilterMenuMobileProps> = ({
 		: () => setIsSortActive(false);
 	const tags = filterValues ? mapFiltersToTags(filterValues) : [];
 
-	const handleSortClick = (key: VisitorSpaceSort, order?: OrderDirection) => {
+	const handleSortClick = (key: SearchSortProp, order?: OrderDirection) => {
 		onSortClick?.(key, order);
 		setIsSortActive(false);
 	};

--- a/src/modules/visitor-space/components/FilterMenu/FilterOption/FilterOption.tsx
+++ b/src/modules/visitor-space/components/FilterMenu/FilterOption/FilterOption.tsx
@@ -4,7 +4,7 @@ import { FC, ReactElement, useCallback, useEffect, useState } from 'react';
 
 import { Icon, IconNamesLight, Overlay } from '@shared/components';
 import useTranslation from '@shared/hooks/use-translation/use-translation';
-import { VisitorSpaceFilterId } from '@visitor-space/types';
+import { SearchFilterId } from '@visitor-space/types';
 
 import { FilterButton } from '../FilterButton';
 import FilterForm from '../FilterForm/FilterForm';
@@ -70,15 +70,15 @@ const FilterOption: FC<FilterOptionProps> = ({
 	const renderCheckbox = (): ReactElement =>
 		renderFilterForm('c-filter-menu__form--inline', true);
 
-	const FILTER_MENU_HEIGHTS: Partial<Record<VisitorSpaceFilterId, string>> = {
-		[VisitorSpaceFilterId.Medium]: '63.7rem',
-		[VisitorSpaceFilterId.Duration]: '48.1rem',
-		[VisitorSpaceFilterId.Created]: '61.3rem',
-		[VisitorSpaceFilterId.Published]: '61.3rem',
-		[VisitorSpaceFilterId.Creator]: '33.5rem',
-		[VisitorSpaceFilterId.Language]: '53.7rem',
-		[VisitorSpaceFilterId.Maintainers]: '63.7rem',
-		[VisitorSpaceFilterId.Advanced]: '60.1rem',
+	const FILTER_MENU_HEIGHTS: Partial<Record<SearchFilterId, string>> = {
+		[SearchFilterId.Medium]: '63.7rem',
+		[SearchFilterId.Duration]: '48.1rem',
+		[SearchFilterId.Created]: '61.3rem',
+		[SearchFilterId.Published]: '61.3rem',
+		[SearchFilterId.Creator]: '33.5rem',
+		[SearchFilterId.Language]: '53.7rem',
+		[SearchFilterId.Maintainers]: '63.7rem',
+		[SearchFilterId.Advanced]: '60.1rem',
 	};
 	const renderModal = (): ReactElement => (
 		<>

--- a/src/modules/visitor-space/components/FilterMenu/FilterSort/FilterSort.tsx
+++ b/src/modules/visitor-space/components/FilterMenu/FilterSort/FilterSort.tsx
@@ -9,7 +9,7 @@ import { FC, useState } from 'react';
 
 import { IconNamesLight, Overlay } from '@shared/components';
 
-import { VisitorSpaceSort } from '../../../types';
+import { SearchSortProp } from '../../../types';
 import { FilterButton } from '../FilterButton';
 import styles from '../FilterMenu.module.scss';
 import { FilterSortList } from '../FilterSortList';
@@ -27,7 +27,7 @@ const FilterSort: FC<FilterSortProps> = ({
 
 	const onCloseDropdown = () => setSortOptionsOpen(false);
 
-	const handleOptionClick = (key: VisitorSpaceSort, order?: OrderDirection) => {
+	const handleOptionClick = (key: SearchSortProp, order?: OrderDirection) => {
 		onOptionClick?.(key, order);
 		setSortOptionsOpen(false);
 	};

--- a/src/modules/visitor-space/components/GenreFilterForm/GenreFilterForm.const.ts
+++ b/src/modules/visitor-space/components/GenreFilterForm/GenreFilterForm.const.ts
@@ -1,7 +1,7 @@
 import { ArrayParam } from 'use-query-params';
 import { array, object, SchemaOf, string } from 'yup';
 
-import { VisitorSpaceFilterId } from '../../types';
+import { SearchFilterId } from '../../types';
 
 import { GenreFilterFormState } from './GenreFilterForm.types';
 
@@ -11,5 +11,5 @@ export const GENRE_FILTER_FORM_SCHEMA = (): SchemaOf<GenreFilterFormState> =>
 	});
 
 export const GENRE_FILTER_FORM_QUERY_PARAM_CONFIG = {
-	[VisitorSpaceFilterId.Genre]: ArrayParam,
+	[SearchFilterId.Genre]: ArrayParam,
 };

--- a/src/modules/visitor-space/components/GenreFilterForm/GenreFilterForm.tsx
+++ b/src/modules/visitor-space/components/GenreFilterForm/GenreFilterForm.tsx
@@ -11,7 +11,7 @@ import { SearchBar } from '@shared/components';
 import useTranslation from '@shared/hooks/use-translation/use-translation';
 import { selectIeObjectsFilterOptions } from '@shared/store/ie-objects';
 import { visitorSpaceLabelKeys } from '@visitor-space/const';
-import { ElasticsearchFieldNames, VisitorSpaceFilterId } from '@visitor-space/types';
+import { ElasticsearchFieldNames, SearchFilterId } from '@visitor-space/types';
 import { sortFilterOptions } from '@visitor-space/utils/sort-filter-options';
 
 import {
@@ -81,7 +81,7 @@ const GenreFilterForm: FC<GenreFilterFormProps> = ({ children, className }) => {
 		<>
 			<div className={clsx(className, 'u-px-20 u-px-32:md')}>
 				<SearchBar
-					id={`${visitorSpaceLabelKeys.filters.title}--${VisitorSpaceFilterId.Genre}`}
+					id={`${visitorSpaceLabelKeys.filters.title}--${SearchFilterId.Genre}`}
 					value={search}
 					variants={['rounded', 'grey', 'icon--double', 'icon-clickable']}
 					placeholder={tText(

--- a/src/modules/visitor-space/components/KeywordsFilterForm/KeywordsFilterForm.const.ts
+++ b/src/modules/visitor-space/components/KeywordsFilterForm/KeywordsFilterForm.const.ts
@@ -1,7 +1,7 @@
 import { ArrayParam } from 'use-query-params';
 import { array, object, SchemaOf, string } from 'yup';
 
-import { VisitorSpaceFilterId } from '../../types';
+import { SearchFilterId } from '../../types';
 
 import { KeywordsFilterFormState } from './KeywordsFilterForm.types';
 
@@ -11,5 +11,5 @@ export const KEYWORDS_FILTER_FORM_SCHEMA = (): SchemaOf<KeywordsFilterFormState>
 	});
 
 export const KEYWORDS_FILTER_FORM_QUERY_PARAM_CONFIG = {
-	[VisitorSpaceFilterId.Keywords]: ArrayParam,
+	[SearchFilterId.Keywords]: ArrayParam,
 };

--- a/src/modules/visitor-space/components/LanguageFilterForm/LanguageFilterForm.const.ts
+++ b/src/modules/visitor-space/components/LanguageFilterForm/LanguageFilterForm.const.ts
@@ -1,7 +1,7 @@
 import { ArrayParam } from 'use-query-params';
 import { array, object, SchemaOf, string } from 'yup';
 
-import { VisitorSpaceFilterId } from '../../types';
+import { SearchFilterId } from '../../types';
 
 import { LanguageFilterFormState } from './LanguageFilterForm.types';
 
@@ -11,5 +11,5 @@ export const LANGUAGE_FILTER_FORM_SCHEMA = (): SchemaOf<LanguageFilterFormState>
 	});
 
 export const LANGUAGE_FILTER_FORM_QUERY_PARAM_CONFIG = {
-	[VisitorSpaceFilterId.Language]: ArrayParam,
+	[SearchFilterId.Language]: ArrayParam,
 };

--- a/src/modules/visitor-space/components/LanguageFilterForm/LanguageFilterForm.tsx
+++ b/src/modules/visitor-space/components/LanguageFilterForm/LanguageFilterForm.tsx
@@ -21,7 +21,7 @@ import { visitorSpaceLabelKeys } from '@visitor-space/const';
 import {
 	ElasticsearchFieldNames,
 	FILTER_LABEL_VALUE_DELIMITER,
-	VisitorSpaceFilterId,
+	SearchFilterId,
 } from '@visitor-space/types';
 import { sortFilterOptions } from '@visitor-space/utils/sort-filter-options';
 
@@ -39,7 +39,7 @@ const LanguageFilterForm: FC<LanguageFilterFormProps> = ({ children, className }
 
 	// Contains the options that have already been applied and are present in the url
 	const appliedSelectedLanguageCodes = compact(
-		(query[VisitorSpaceFilterId.Language] || []).map(
+		(query[SearchFilterId.Language] || []).map(
 			(languageCodeAndName) => languageCodeAndName?.split(FILTER_LABEL_VALUE_DELIMITER)?.[0]
 		)
 	);
@@ -101,7 +101,7 @@ const LanguageFilterForm: FC<LanguageFilterFormProps> = ({ children, className }
 		<>
 			<div className={clsx(className, 'u-px-20 u-px-32:md')}>
 				<SearchBar
-					id={`${visitorSpaceLabelKeys.filters.title}--${VisitorSpaceFilterId.Language}`}
+					id={`${visitorSpaceLabelKeys.filters.title}--${SearchFilterId.Language}`}
 					value={search}
 					variants={['rounded', 'grey', 'icon--double', 'icon-clickable']}
 					placeholder={tText(

--- a/src/modules/visitor-space/components/MaintainerFilterForm/MaintainerFilterForm.const.ts
+++ b/src/modules/visitor-space/components/MaintainerFilterForm/MaintainerFilterForm.const.ts
@@ -1,7 +1,7 @@
 import { ArrayParam } from 'use-query-params';
 import { array, object, SchemaOf, string } from 'yup';
 
-import { VisitorSpaceFilterId } from '../../types';
+import { SearchFilterId } from '../../types';
 
 import { MaintainerFilterFormState } from './MaintainerFilterForm.types';
 
@@ -11,5 +11,5 @@ export const MAINTAINER_FILTER_FORM_SCHEMA = (): SchemaOf<MaintainerFilterFormSt
 	});
 
 export const MAINTAINER_FILTER_FORM_QUERY_PARAM_CONFIG = {
-	[VisitorSpaceFilterId.Maintainers]: ArrayParam,
+	[SearchFilterId.Maintainers]: ArrayParam,
 };

--- a/src/modules/visitor-space/components/MaintainerFilterForm/MaintainerFilterForm.tsx
+++ b/src/modules/visitor-space/components/MaintainerFilterForm/MaintainerFilterForm.tsx
@@ -16,7 +16,7 @@ import { useGetContentPartners } from '@visitor-space/hooks/get-content-partner'
 import {
 	ElasticsearchFieldNames,
 	FILTER_LABEL_VALUE_DELIMITER,
-	VisitorSpaceFilterId,
+	SearchFilterId,
 } from '@visitor-space/types';
 import { sortFilterOptions } from '@visitor-space/utils/sort-filter-options';
 
@@ -37,7 +37,7 @@ const MaintainerFilterForm: FC<MaintainerFilterFormProps> = ({ children, classNa
 
 	// Contains the filters that have already been applied and are present in the url
 	const appliedSelectedMaintainerIds = compact(
-		(query[VisitorSpaceFilterId.Maintainers] || []).map(
+		(query[SearchFilterId.Maintainers] || []).map(
 			(maintainerIdAndName) => maintainerIdAndName?.split(FILTER_LABEL_VALUE_DELIMITER)?.[0]
 		)
 	);
@@ -110,7 +110,7 @@ const MaintainerFilterForm: FC<MaintainerFilterFormProps> = ({ children, classNa
 		<>
 			<div className={clsx(className, 'u-px-20 u-px-32:md')}>
 				<SearchBar
-					id={`${visitorSpaceLabelKeys.filters.title}--${VisitorSpaceFilterId.Maintainers}`}
+					id={`${visitorSpaceLabelKeys.filters.title}--${SearchFilterId.Maintainers}`}
 					value={search}
 					variants={['rounded', 'grey', 'icon--double', 'icon-clickable']}
 					placeholder={tText(

--- a/src/modules/visitor-space/components/MediumFilterForm/MediumFilterForm.const.ts
+++ b/src/modules/visitor-space/components/MediumFilterForm/MediumFilterForm.const.ts
@@ -1,7 +1,7 @@
 import { ArrayParam } from 'use-query-params';
 import { array, object, SchemaOf, string } from 'yup';
 
-import { VisitorSpaceFilterId } from '../../types';
+import { SearchFilterId } from '../../types';
 
 import { MediumFilterFormState } from './MediumFilterForm.types';
 
@@ -11,5 +11,5 @@ export const MEDIUM_FILTER_FORM_SCHEMA = (): SchemaOf<MediumFilterFormState> =>
 	});
 
 export const MEDIUM_FILTER_FORM_QUERY_PARAM_CONFIG = {
-	[VisitorSpaceFilterId.Medium]: ArrayParam,
+	[SearchFilterId.Medium]: ArrayParam,
 };

--- a/src/modules/visitor-space/components/MediumFilterForm/MediumFilterForm.tsx
+++ b/src/modules/visitor-space/components/MediumFilterForm/MediumFilterForm.tsx
@@ -11,7 +11,7 @@ import { SearchBar } from '@shared/components';
 import useTranslation from '@shared/hooks/use-translation/use-translation';
 import { selectIeObjectsFilterOptions } from '@shared/store/ie-objects';
 import { visitorSpaceLabelKeys } from '@visitor-space/const';
-import { ElasticsearchFieldNames, VisitorSpaceFilterId } from '@visitor-space/types';
+import { ElasticsearchFieldNames, SearchFilterId } from '@visitor-space/types';
 import { sortFilterOptions } from '@visitor-space/utils/sort-filter-options';
 
 import {
@@ -80,7 +80,7 @@ const MediumFilterForm: FC<MediumFilterFormProps> = ({ children, className }) =>
 		<>
 			<div className={clsx(className, 'u-px-20 u-px-32:md')}>
 				<SearchBar
-					id={`${visitorSpaceLabelKeys.filters.title}--${VisitorSpaceFilterId.Medium}`}
+					id={`${visitorSpaceLabelKeys.filters.title}--${SearchFilterId.Medium}`}
 					value={search}
 					variants={['rounded', 'grey', 'icon--double', 'icon-clickable']}
 					placeholder={tText(

--- a/src/modules/visitor-space/components/PublishedFilterForm/PublishedFilterForm.const.ts
+++ b/src/modules/visitor-space/components/PublishedFilterForm/PublishedFilterForm.const.ts
@@ -3,7 +3,7 @@ import { mixed, object, SchemaOf, string } from 'yup';
 import { Operator } from '@shared/types';
 
 import { AdvancedFilterArrayParam } from '../../const/query-params';
-import { VisitorSpaceFilterId } from '../../types';
+import { SearchFilterId } from '../../types';
 
 import { PublishedFilterFormState } from './PublishedFilterForm.types';
 
@@ -14,5 +14,5 @@ export const PUBLISHED_FILTER_FORM_SCHEMA = (): SchemaOf<PublishedFilterFormStat
 	});
 
 export const PUBLISHED_FILTER_FORM_QUERY_PARAM_CONFIG = {
-	[VisitorSpaceFilterId.Published]: AdvancedFilterArrayParam,
+	[SearchFilterId.Published]: AdvancedFilterArrayParam,
 };

--- a/src/modules/visitor-space/const/index.tsx
+++ b/src/modules/visitor-space/const/index.tsx
@@ -14,7 +14,7 @@ import { Icon, IconNamesLight } from '@shared/components';
 import { VIEW_TOGGLE_OPTIONS } from '@shared/const';
 import { QUERY_PARAM_KEY } from '@shared/const/query-param-keys';
 import { tText } from '@shared/helpers/translate';
-import { VisitorSpaceMediaType } from '@shared/types';
+import { SearchPageMediaType } from '@shared/types';
 import {
 	AdvancedFilterForm,
 	ConsultableMediaFilterForm,
@@ -33,7 +33,7 @@ import {
 	PublishedFilterForm,
 } from '@visitor-space/components';
 
-import { VisitorSpaceFilterId, VisitorSpaceSort, VisitorSpaceStatus } from '../types';
+import { SearchFilterId, SearchSortProp, VisitorSpaceStatus } from '../types';
 
 import { AdvancedFilterArrayParam } from './query-params';
 
@@ -44,58 +44,58 @@ export const PUBLIC_COLLECTION = ''; // No maintainer query param means the publ
 
 export const DEFAULT_VISITOR_SPACE_COLOR = '#00c8aa';
 
-export const VISITOR_SPACE_ITEM_COUNT = 24;
+export const SEARCH_RESULTS_PAGE_SIZE = 24;
 
 export const VISITOR_SPACE_QUERY_PARAM_INIT: Record<
-	VisitorSpaceFilterId | QUERY_PARAM_KEY.SEARCH_QUERY_KEY,
+	SearchFilterId | QUERY_PARAM_KEY.SEARCH_QUERY_KEY,
 	string | undefined
-> & { page: number; orderProp: VisitorSpaceSort; orderDirection: OrderDirection } = {
+> & { page: number; orderProp: SearchSortProp; orderDirection: OrderDirection } = {
 	// Filters
 	[QUERY_PARAM_KEY.SEARCH_QUERY_KEY]: undefined,
-	[VisitorSpaceFilterId.Format]: VisitorSpaceMediaType.All,
-	[VisitorSpaceFilterId.Maintainer]: undefined,
-	[VisitorSpaceFilterId.Maintainers]: undefined,
-	[VisitorSpaceFilterId.Medium]: undefined,
-	[VisitorSpaceFilterId.Duration]: undefined,
-	[VisitorSpaceFilterId.Created]: undefined,
-	[VisitorSpaceFilterId.Published]: undefined,
-	[VisitorSpaceFilterId.Creator]: undefined,
-	[VisitorSpaceFilterId.Genre]: undefined,
-	[VisitorSpaceFilterId.Keywords]: undefined,
-	[VisitorSpaceFilterId.Language]: undefined,
-	[VisitorSpaceFilterId.Advanced]: undefined,
-	[VisitorSpaceFilterId.ConsultableOnlyOnLocation]: undefined,
-	[VisitorSpaceFilterId.ConsultableMedia]: undefined,
-	[VisitorSpaceFilterId.Cast]: undefined,
-	[VisitorSpaceFilterId.Identifier]: undefined,
-	[VisitorSpaceFilterId.ObjectType]: undefined,
-	[VisitorSpaceFilterId.SpacialCoverage]: undefined,
-	[VisitorSpaceFilterId.TemporalCoverage]: undefined,
+	[SearchFilterId.Format]: SearchPageMediaType.All,
+	[SearchFilterId.Maintainer]: undefined,
+	[SearchFilterId.Maintainers]: undefined,
+	[SearchFilterId.Medium]: undefined,
+	[SearchFilterId.Duration]: undefined,
+	[SearchFilterId.Created]: undefined,
+	[SearchFilterId.Published]: undefined,
+	[SearchFilterId.Creator]: undefined,
+	[SearchFilterId.Genre]: undefined,
+	[SearchFilterId.Keywords]: undefined,
+	[SearchFilterId.Language]: undefined,
+	[SearchFilterId.Advanced]: undefined,
+	[SearchFilterId.ConsultableOnlyOnLocation]: undefined,
+	[SearchFilterId.ConsultableMedia]: undefined,
+	[SearchFilterId.Cast]: undefined,
+	[SearchFilterId.Identifier]: undefined,
+	[SearchFilterId.ObjectType]: undefined,
+	[SearchFilterId.SpacialCoverage]: undefined,
+	[SearchFilterId.TemporalCoverage]: undefined,
 
 	// Pagination
 	page: 1,
 	// Sorting
-	orderProp: VisitorSpaceSort.Relevance,
+	orderProp: SearchSortProp.Relevance,
 	orderDirection: OrderDirection.desc,
 };
 
-export const VISITOR_SPACE_QUERY_PARAM_CONFIG: Record<string, QueryParamConfig<any>> = {
+export const SEARCH_PAGE_QUERY_PARAM_CONFIG: Record<string, QueryParamConfig<any>> = {
 	// Filters
 	format: StringParam,
 	[QUERY_PARAM_KEY.SEARCH_QUERY_KEY]: ArrayParam,
-	[VisitorSpaceFilterId.Maintainer]: StringParam,
-	[VisitorSpaceFilterId.Medium]: ArrayParam,
-	[VisitorSpaceFilterId.Duration]: AdvancedFilterArrayParam,
-	[VisitorSpaceFilterId.Created]: AdvancedFilterArrayParam,
-	[VisitorSpaceFilterId.Published]: AdvancedFilterArrayParam,
-	[VisitorSpaceFilterId.Creator]: StringParam,
-	[VisitorSpaceFilterId.Genre]: ArrayParam,
-	[VisitorSpaceFilterId.Keywords]: ArrayParam,
-	[VisitorSpaceFilterId.Language]: ArrayParam,
-	[VisitorSpaceFilterId.Maintainers]: ArrayParam,
-	[VisitorSpaceFilterId.Advanced]: AdvancedFilterArrayParam,
-	[VisitorSpaceFilterId.ConsultableOnlyOnLocation]: BooleanParam,
-	[VisitorSpaceFilterId.ConsultableMedia]: BooleanParam,
+	[SearchFilterId.Maintainer]: StringParam,
+	[SearchFilterId.Medium]: ArrayParam,
+	[SearchFilterId.Duration]: AdvancedFilterArrayParam,
+	[SearchFilterId.Created]: AdvancedFilterArrayParam,
+	[SearchFilterId.Published]: AdvancedFilterArrayParam,
+	[SearchFilterId.Creator]: StringParam,
+	[SearchFilterId.Genre]: ArrayParam,
+	[SearchFilterId.Keywords]: ArrayParam,
+	[SearchFilterId.Language]: ArrayParam,
+	[SearchFilterId.Maintainers]: ArrayParam,
+	[SearchFilterId.Advanced]: AdvancedFilterArrayParam,
+	[SearchFilterId.ConsultableOnlyOnLocation]: BooleanParam,
+	[SearchFilterId.ConsultableMedia]: BooleanParam,
 	// Pagination
 	page: NumberParam,
 	// Sorting
@@ -107,16 +107,16 @@ export const VISITOR_SPACE_QUERY_PARAM_CONFIG: Record<string, QueryParamConfig<a
 
 export const VISITOR_SPACE_TABS = (): TabProps[] => [
 	{
-		id: VisitorSpaceMediaType.All,
+		id: SearchPageMediaType.All,
 		label: tText('modules/visitor-space/const/index___alles'),
 	},
 	{
-		id: VisitorSpaceMediaType.Video,
+		id: SearchPageMediaType.Video,
 		icon: <Icon name={IconNamesLight.Video} aria-hidden />,
 		label: tText('modules/visitor-space/const/index___videos'),
 	},
 	{
-		id: VisitorSpaceMediaType.Audio,
+		id: SearchPageMediaType.Audio,
 		icon: <Icon name={IconNamesLight.Audio} aria-hidden />,
 		label: tText('modules/visitor-space/const/index___audio'),
 	},
@@ -131,7 +131,7 @@ export const VISITOR_SPACE_FILTERS = (
 	isKeyUser: boolean
 ): FilterMenuFilterOption[] => [
 	{
-		id: VisitorSpaceFilterId.ConsultableMedia,
+		id: SearchFilterId.ConsultableMedia,
 		label: tText('modules/visitor-space/const/index___alles-wat-raadpleegbaar-is'),
 		form: ConsultableMediaFilterForm,
 		type: FilterMenuType.Checkbox,
@@ -140,7 +140,7 @@ export const VISITOR_SPACE_FILTERS = (
 		},
 	},
 	{
-		id: VisitorSpaceFilterId.ConsultableOnlyOnLocation,
+		id: SearchFilterId.ConsultableOnlyOnLocation,
 		label: tText('modules/visitor-space/const/index___enkel-ter-plaatse-beschikbaar'),
 		form: ConsultableOnlyOnLocationFilterForm,
 		type: FilterMenuType.Checkbox,
@@ -149,38 +149,38 @@ export const VISITOR_SPACE_FILTERS = (
 		},
 	},
 	{
-		id: VisitorSpaceFilterId.Medium,
+		id: SearchFilterId.Medium,
 		label: tText('modules/visitor-space/const/index___analoge-drager'),
 		form: MediumFilterForm,
 		type: FilterMenuType.Modal,
 	},
 	{
-		id: VisitorSpaceFilterId.Duration,
+		id: SearchFilterId.Duration,
 		label: tText('modules/visitor-space/const/index___duurtijd'),
 		form: DurationFilterForm,
 		type: FilterMenuType.Modal,
 	},
 	{
-		id: VisitorSpaceFilterId.Created,
+		id: SearchFilterId.Created,
 		label: tText('modules/visitor-space/const/index___creatiedatum'),
 		form: CreatedFilterForm,
 		type: FilterMenuType.Modal,
 	},
 	{
-		id: VisitorSpaceFilterId.Published,
+		id: SearchFilterId.Published,
 		label: tText('modules/visitor-space/const/index___publicatiedatum'),
 		form: PublishedFilterForm,
 		type: FilterMenuType.Modal,
 	},
 	{
-		id: VisitorSpaceFilterId.Creator,
+		id: SearchFilterId.Creator,
 		label: tText('modules/visitor-space/const/index___maker'),
 		form: CreatorFilterForm,
 		type: FilterMenuType.Modal,
 	},
 	// Disabled for https://meemoo.atlassian.net/browse/ARC-246
 	{
-		id: VisitorSpaceFilterId.Genre,
+		id: SearchFilterId.Genre,
 		label: tText('modules/visitor-space/const/index___genre'),
 		form: GenreFilterForm,
 		type: FilterMenuType.Modal,
@@ -188,20 +188,20 @@ export const VISITOR_SPACE_FILTERS = (
 	},
 	// Disabled for https://meemoo.atlassian.net/browse/ARC-246
 	{
-		id: VisitorSpaceFilterId.Keywords,
+		id: SearchFilterId.Keywords,
 		label: tText('modules/visitor-space/const/index___trefwoorden'),
 		form: KeywordsFilterForm,
 		type: FilterMenuType.Modal,
 		isDisabled: () => true,
 	},
 	{
-		id: VisitorSpaceFilterId.Language,
+		id: SearchFilterId.Language,
 		label: tText('modules/visitor-space/const/index___taal'),
 		form: LanguageFilterForm,
 		type: FilterMenuType.Modal,
 	},
 	{
-		id: VisitorSpaceFilterId.Maintainers,
+		id: SearchFilterId.Maintainers,
 		label: tText('modules/visitor-space/const/index___aanbieder'),
 		form: MaintainerFilterForm,
 		type: FilterMenuType.Modal,
@@ -210,7 +210,7 @@ export const VISITOR_SPACE_FILTERS = (
 		},
 	},
 	{
-		id: VisitorSpaceFilterId.Advanced,
+		id: SearchFilterId.Advanced,
 		icon: IconNamesLight.DotsHorizontal,
 		label: tText('modules/visitor-space/const/index___geavanceerd'),
 		form: AdvancedFilterForm,
@@ -218,35 +218,31 @@ export const VISITOR_SPACE_FILTERS = (
 	},
 ];
 
-export const VISITOR_SPACE_ACTIVE_SORT_MAP = (): { [key in VisitorSpaceSort]: string } => ({
-	[VisitorSpaceSort.Date]: tText('modules/visitor-space/const/index___sorteer-op-datum'),
-	[VisitorSpaceSort.Relevance]: tText(
-		'modules/visitor-space/const/index___sorteer-op-relevantie'
-	),
-	[VisitorSpaceSort.Title]: tText('modules/visitor-space/const/index___sorteer-op-titel'),
-	[VisitorSpaceSort.Archived]: tText(
-		'modules/visitor-space/const/index___sorteer-op-gearchiveerd'
-	),
+export const VISITOR_SPACE_ACTIVE_SORT_MAP = (): { [key in SearchSortProp]: string } => ({
+	[SearchSortProp.Date]: tText('modules/visitor-space/const/index___sorteer-op-datum'),
+	[SearchSortProp.Relevance]: tText('modules/visitor-space/const/index___sorteer-op-relevantie'),
+	[SearchSortProp.Title]: tText('modules/visitor-space/const/index___sorteer-op-titel'),
+	[SearchSortProp.Archived]: tText('modules/visitor-space/const/index___sorteer-op-gearchiveerd'),
 });
 
 export const VISITOR_SPACE_SORT_OPTIONS = (): FilterMenuSortOption[] => [
 	{
 		label: tText('modules/visitor-space/const/index___relevantie'),
-		orderProp: VisitorSpaceSort.Relevance,
+		orderProp: SearchSortProp.Relevance,
 	},
 	{
 		label: tText('modules/visitor-space/const/index___datum-oplopend'),
-		orderProp: VisitorSpaceSort.Date,
+		orderProp: SearchSortProp.Date,
 		orderDirection: OrderDirection.asc,
 	},
 	{
 		label: tText('modules/visitor-space/const/index___datum-aflopend'),
-		orderProp: VisitorSpaceSort.Date,
+		orderProp: SearchSortProp.Date,
 		orderDirection: OrderDirection.desc,
 	},
 	{
 		label: tText('modules/visitor-space/const/index___gearchiveerd'),
-		orderProp: VisitorSpaceSort.Archived,
+		orderProp: SearchSortProp.Archived,
 		orderDirection: OrderDirection.desc,
 	},
 	// schema_name niet sorteerbaar in https://meemoo.atlassian.net/wiki/pages/viewpage.action?pageId=3309174878&pageVersion=3

--- a/src/modules/visitor-space/types/index.ts
+++ b/src/modules/visitor-space/types/index.ts
@@ -7,24 +7,22 @@ import { DecodedValueMap } from 'use-query-params';
 import { DefaultComponentProps, IeObjectTypes, Operator } from '@shared/types';
 import { OnFilterMenuFormSubmit } from '@visitor-space/components';
 
-import { VISITOR_SPACE_QUERY_PARAM_CONFIG } from '../const';
+import { SEARCH_PAGE_QUERY_PARAM_CONFIG } from '../const';
 
 import { MetadataProp } from './metadata';
 
 export * from './metadata';
 
-export type VisitorSpaceQueryParams = Partial<
-	DecodedValueMap<typeof VISITOR_SPACE_QUERY_PARAM_CONFIG>
->;
+export type SearchPageQueryParams = Partial<DecodedValueMap<typeof SEARCH_PAGE_QUERY_PARAM_CONFIG>>;
 
-export enum VisitorSpaceSort {
+export enum SearchSortProp {
 	Date = 'created',
 	Relevance = 'relevance',
 	Title = 'name',
 	Archived = 'archived',
 }
 
-export enum VisitorSpaceFilterId {
+export enum SearchFilterId {
 	Format = 'format',
 	Advanced = 'advanced',
 	Created = 'created',
@@ -90,7 +88,7 @@ export interface DefaultFilterFormProps<Values extends FieldValues>
 
 export interface InlineFilterFormProps<Values = unknown> extends DefaultComponentProps {
 	children?: React.ReactNode;
-	id: VisitorSpaceFilterId;
+	id: SearchFilterId;
 	label: string;
 	onFormSubmit: OnFilterMenuFormSubmit;
 	disabled?: boolean;

--- a/src/modules/visitor-space/utils/elastic-filters/elastic-filters.ts
+++ b/src/modules/visitor-space/utils/elastic-filters/elastic-filters.ts
@@ -10,11 +10,7 @@ import {
 } from '@shared/types';
 
 import { VISITOR_SPACE_QUERY_PARAM_INIT } from '../../const';
-import {
-	FILTER_LABEL_VALUE_DELIMITER,
-	VisitorSpaceFilterId,
-	VisitorSpaceQueryParams,
-} from '../../types';
+import { FILTER_LABEL_VALUE_DELIMITER, SearchFilterId, SearchPageQueryParams } from '../../types';
 import { mapAdvancedToElastic } from '../map-filters';
 
 export const VISITOR_SPACE_LICENSES = [
@@ -23,11 +19,11 @@ export const VISITOR_SPACE_LICENSES = [
 ];
 
 export const mapMaintainerToElastic = (
-	query: VisitorSpaceQueryParams,
+	query: SearchPageQueryParams,
 	activeVisitorSpace: Visit | undefined
 ): IeObjectsSearchFilter[] => {
 	const maintainerId =
-		activeVisitorSpace?.spaceSlug === query?.[VisitorSpaceFilterId.Maintainer]
+		activeVisitorSpace?.spaceSlug === query?.[SearchFilterId.Maintainer]
 			? activeVisitorSpace?.spaceMaintainerId
 			: '';
 
@@ -63,7 +59,7 @@ export const mapMaintainerToElastic = (
 	]);
 };
 
-const getFiltersForSearchTerms = (query: VisitorSpaceQueryParams): IeObjectsSearchFilter[] => {
+const getFiltersForSearchTerms = (query: SearchPageQueryParams): IeObjectsSearchFilter[] => {
 	if (!query[QUERY_PARAM_KEY.SEARCH_QUERY_KEY]) {
 		return [];
 	}
@@ -79,7 +75,7 @@ const getFiltersForSearchTerms = (query: VisitorSpaceQueryParams): IeObjectsSear
 	});
 };
 
-export const mapFiltersToElastic = (query: VisitorSpaceQueryParams): IeObjectsSearchFilter[] => {
+export const mapFiltersToElastic = (query: SearchPageQueryParams): IeObjectsSearchFilter[] => {
 	return [
 		// Searchbar
 		...getFiltersForSearchTerms(query),
@@ -93,37 +89,37 @@ export const mapFiltersToElastic = (query: VisitorSpaceQueryParams): IeObjectsSe
 		{
 			field: IeObjectsSearchFilterField.MEDIUM,
 			operator: IeObjectsSearchOperator.IS,
-			multiValue: compact(query[VisitorSpaceFilterId.Medium] || []) as string[],
+			multiValue: compact(query[SearchFilterId.Medium] || []) as string[],
 		},
 		// Duration
-		...(query[VisitorSpaceFilterId.Duration] || []).flatMap(mapAdvancedToElastic),
+		...(query[SearchFilterId.Duration] || []).flatMap(mapAdvancedToElastic),
 		// Created
-		...(query[VisitorSpaceFilterId.Created] || []).flatMap(mapAdvancedToElastic),
+		...(query[SearchFilterId.Created] || []).flatMap(mapAdvancedToElastic),
 		// Published
-		...(query[VisitorSpaceFilterId.Published] || []).flatMap(mapAdvancedToElastic),
+		...(query[SearchFilterId.Published] || []).flatMap(mapAdvancedToElastic),
 		// Creator
 		{
 			field: IeObjectsSearchFilterField.CREATOR,
 			operator: IeObjectsSearchOperator.CONTAINS,
-			value: (query[VisitorSpaceFilterId.Creator] as string) || '',
+			value: (query[SearchFilterId.Creator] as string) || '',
 		},
 		// Genre
 		{
 			field: IeObjectsSearchFilterField.GENRE,
 			operator: IeObjectsSearchOperator.IS,
-			multiValue: compact(query[VisitorSpaceFilterId.Genre] || []) as string[],
+			multiValue: compact(query[SearchFilterId.Genre] || []) as string[],
 		},
 		// Keywords
 		{
 			field: IeObjectsSearchFilterField.KEYWORD,
 			operator: IeObjectsSearchOperator.IS,
-			multiValue: compact(query[VisitorSpaceFilterId.Keywords] || []) as string[],
+			multiValue: compact(query[SearchFilterId.Keywords] || []) as string[],
 		},
 		// Language
 		{
 			field: IeObjectsSearchFilterField.LANGUAGE,
 			operator: IeObjectsSearchOperator.IS,
-			multiValue: (compact(query[VisitorSpaceFilterId.Language] || []) as string[]).map(
+			multiValue: (compact(query[SearchFilterId.Language] || []) as string[]).map(
 				(language) => language?.split(FILTER_LABEL_VALUE_DELIMITER)[0]
 			) as string[],
 		},
@@ -131,7 +127,7 @@ export const mapFiltersToElastic = (query: VisitorSpaceQueryParams): IeObjectsSe
 		{
 			field: IeObjectsSearchFilterField.MAINTAINER_ID,
 			operator: IeObjectsSearchOperator.IS,
-			multiValue: (compact(query[VisitorSpaceFilterId.Maintainers] || []) as string[]).map(
+			multiValue: (compact(query[SearchFilterId.Maintainers] || []) as string[]).map(
 				(maintainerId: string) =>
 					maintainerId.split(FILTER_LABEL_VALUE_DELIMITER)[0] as string
 			),
@@ -140,13 +136,13 @@ export const mapFiltersToElastic = (query: VisitorSpaceQueryParams): IeObjectsSe
 		{
 			field: IeObjectsSearchFilterField.CONSULTABLE_ONLY_ON_LOCATION,
 			operator: IeObjectsSearchOperator.IS,
-			value: query[VisitorSpaceFilterId.ConsultableOnlyOnLocation] ? 'true' : '',
+			value: query[SearchFilterId.ConsultableOnlyOnLocation] ? 'true' : '',
 		},
 		// Consultable Media
 		{
 			field: IeObjectsSearchFilterField.CONSULTABLE_MEDIA,
 			operator: IeObjectsSearchOperator.IS,
-			value: query[VisitorSpaceFilterId.ConsultableMedia] ? 'true' : '',
+			value: query[SearchFilterId.ConsultableMedia] ? 'true' : '',
 		},
 		// Advanced
 		...(query.advanced || []).flatMap(mapAdvancedToElastic),

--- a/src/modules/visitor-space/utils/map-filters/map-filters.tsx
+++ b/src/modules/visitor-space/utils/map-filters/map-filters.tsx
@@ -14,9 +14,9 @@ import {
 	AdvancedFilter,
 	FILTER_LABEL_VALUE_DELIMITER,
 	MetadataProp,
+	SearchFilterId,
+	SearchPageQueryParams,
 	TagIdentity,
-	VisitorSpaceFilterId,
-	VisitorSpaceQueryParams,
 } from '../../types';
 import {
 	getAdvancedProperties,
@@ -86,7 +86,7 @@ export const mapArrayParamToTags = (
 
 export const mapAdvancedToTags = (
 	advanced: Array<AdvancedFilter>,
-	key: VisitorSpaceFilterId = VisitorSpaceFilterId.Advanced
+	key: SearchFilterId = SearchFilterId.Advanced
 ): TagIdentity[] => {
 	return advanced.map((advanced: AdvancedFilter) => {
 		const prop = advanced.prop as MetadataProp;
@@ -145,7 +145,7 @@ export const mapAdvancedToTags = (
 	});
 };
 
-export const mapFiltersToTags = (query: VisitorSpaceQueryParams): TagIdentity[] => {
+export const mapFiltersToTags = (query: SearchPageQueryParams): TagIdentity[] => {
 	return [
 		...mapArrayParamToTags(
 			query[QUERY_PARAM_KEY.SEARCH_QUERY_KEY] || [],
@@ -153,65 +153,56 @@ export const mapFiltersToTags = (query: VisitorSpaceQueryParams): TagIdentity[] 
 			QUERY_PARAM_KEY.SEARCH_QUERY_KEY
 		),
 		...mapArrayParamToTags(
-			query[VisitorSpaceFilterId.Medium] || [],
+			query[SearchFilterId.Medium] || [],
 			getFilterLabel(MetadataProp.Medium),
-			VisitorSpaceFilterId.Medium
+			SearchFilterId.Medium
 		),
 		// Also uses the advanced filters since we encode "between" into 2 separate advanced filters: gt and lt
-		...mapAdvancedToTags(
-			query[VisitorSpaceFilterId.Duration] || [],
-			VisitorSpaceFilterId.Duration
-		),
+		...mapAdvancedToTags(query[SearchFilterId.Duration] || [], SearchFilterId.Duration),
 		// Also uses the advanced filters since we encode "between" into 2 separate advanced filters: gt and lt
-		...mapAdvancedToTags(
-			query[VisitorSpaceFilterId.Created] || [],
-			VisitorSpaceFilterId.Created
-		),
+		...mapAdvancedToTags(query[SearchFilterId.Created] || [], SearchFilterId.Created),
 		// Also uses the advanced filters since we encode "between" into 2 separate advanced filters: gt and lt
-		...mapAdvancedToTags(
-			query[VisitorSpaceFilterId.Published] || [],
-			VisitorSpaceFilterId.Published
-		),
+		...mapAdvancedToTags(query[SearchFilterId.Published] || [], SearchFilterId.Published),
 		...mapArrayParamToTags(
-			query[VisitorSpaceFilterId.Creator] || [],
+			query[SearchFilterId.Creator] || [],
 			getFilterLabel(MetadataProp.Creator),
-			VisitorSpaceFilterId.Creator
+			SearchFilterId.Creator
 		),
 		...mapArrayParamToTags(
-			query[VisitorSpaceFilterId.Genre] || [],
+			query[SearchFilterId.Genre] || [],
 			getFilterLabel(MetadataProp.Genre),
-			VisitorSpaceFilterId.Genre
+			SearchFilterId.Genre
 		),
 		...mapArrayParamToTags(
-			query[VisitorSpaceFilterId.Keywords] || [],
+			query[SearchFilterId.Keywords] || [],
 			getFilterLabel(MetadataProp.Keywords),
-			VisitorSpaceFilterId.Keywords
+			SearchFilterId.Keywords
 		),
 		...mapArrayParamToTags(
-			query[VisitorSpaceFilterId.Language] || [],
+			query[SearchFilterId.Language] || [],
 			getFilterLabel(MetadataProp.Language),
-			VisitorSpaceFilterId.Language
+			SearchFilterId.Language
 		),
 		...mapBooleanParamToTag(
-			query[VisitorSpaceFilterId.ConsultableMedia] || false,
+			query[SearchFilterId.ConsultableMedia] || false,
 			tText(
 				'modules/visitor-space/utils/map-filters/map-filters___alles-wat-raadpleegbaar-is'
 			),
-			VisitorSpaceFilterId.ConsultableMedia
+			SearchFilterId.ConsultableMedia
 		),
 		...mapArrayParamToTags(
-			query[VisitorSpaceFilterId.Maintainers] || [],
+			query[SearchFilterId.Maintainers] || [],
 			tText('modules/visitor-space/utils/map-filters/map-filters___aanbieders'),
-			VisitorSpaceFilterId.Maintainers
+			SearchFilterId.Maintainers
 		),
 		...mapBooleanParamToTag(
-			query[VisitorSpaceFilterId.ConsultableOnlyOnLocation] || false,
+			query[SearchFilterId.ConsultableOnlyOnLocation] || false,
 			tText(
 				'modules/visitor-space/utils/map-filters/map-filters___raadpleegbaar-ter-plaatse'
 			),
-			VisitorSpaceFilterId.ConsultableOnlyOnLocation
+			SearchFilterId.ConsultableOnlyOnLocation
 		),
-		...mapAdvancedToTags(query[VisitorSpaceFilterId.Advanced] || []),
+		...mapAdvancedToTags(query[SearchFilterId.Advanced] || []),
 	];
 };
 

--- a/src/modules/visitor-space/views/VisitPage.tsx
+++ b/src/modules/visitor-space/views/VisitPage.tsx
@@ -15,7 +15,7 @@ import { AccessStatus } from '@shared/types';
 import { DefaultSeoInfo } from '@shared/types/seo';
 import { useGetOrganisationBySlug } from '@visitor-space/hooks/get-organisation-by-slug';
 import { useGetVisitorSpace } from '@visitor-space/hooks/get-visitor-space';
-import { VisitorSpaceFilterId } from '@visitor-space/types';
+import { SearchFilterId } from '@visitor-space/types';
 
 import { useGetVisitAccessStatus } from '../../visit-requests/hooks/get-visit-access-status';
 import { VisitorLayout } from '../../visitor-layout';
@@ -115,7 +115,7 @@ export const VisitPage: FC<VisitPageProps> = () => {
 							<NextRedirect
 								to={stringifyUrl({
 									url: ROUTES_BY_LOCALE[locale].search,
-									query: { [VisitorSpaceFilterId.Maintainer]: slug },
+									query: { [SearchFilterId.Maintainer]: slug },
 								})}
 								method="replace"
 							/>
@@ -133,7 +133,7 @@ export const VisitPage: FC<VisitPageProps> = () => {
 								to={stringifyUrl({
 									url: ROUTES_BY_LOCALE[locale].search,
 									query: {
-										[VisitorSpaceFilterId.Maintainers]:
+										[SearchFilterId.Maintainers]:
 											organisation?.schemaIdentifier +
 											'---' +
 											organisation?.schemaName,

--- a/src/pages/[slug]/index.tsx
+++ b/src/pages/[slug]/index.tsx
@@ -135,7 +135,7 @@ const DynamicRouteResolver: NextPage<DynamicRouteResolverProps & UserProps> = ({
 	);
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DynamicRouteResolverProps>> {
 	let title: string | null = null;

--- a/src/pages/account/map-delen/[folderId]/index.tsx
+++ b/src/pages/account/map-delen/[folderId]/index.tsx
@@ -15,7 +15,7 @@ const AccountSharedFolderDutch: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <AccountSharedFolder url={url} folderId={folderId} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/account/mijn-bezoek-historiek/index.tsx
+++ b/src/pages/account/mijn-bezoek-historiek/index.tsx
@@ -11,7 +11,7 @@ const AccountMyHistoryDutch: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <AccountMyHistory url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/account/mijn-mappen/[folderSlug]/index.tsx
+++ b/src/pages/account/mijn-mappen/[folderSlug]/index.tsx
@@ -15,7 +15,7 @@ const AccountMyFoldersDutch: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <AccountMyFolders folderSlug={folderSlug} url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/account/mijn-materiaalaanvragen/index.tsx
+++ b/src/pages/account/mijn-materiaalaanvragen/index.tsx
@@ -11,7 +11,7 @@ const AccountMyMaterialRequestsDutch: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <AccountMyMaterialRequests url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/account/mijn-profiel/index.tsx
+++ b/src/pages/account/mijn-profiel/index.tsx
@@ -11,7 +11,7 @@ const AccountMyProfileDutch: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <AccountMyProfile url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/account/my-folders/[folderSlug]/index.tsx
+++ b/src/pages/account/my-folders/[folderSlug]/index.tsx
@@ -15,7 +15,7 @@ const AccountMyFoldersEnglish: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <AccountMyFolders folderSlug={folderSlug} url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/account/my-materialrequests/index.tsx
+++ b/src/pages/account/my-materialrequests/index.tsx
@@ -11,7 +11,7 @@ const AccountMyMaterialRequestsEnglish: NextPage<DefaultSeoInfo> = ({ url }) => 
 	return <AccountMyMaterialRequests url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/account/my-profile/index.tsx
+++ b/src/pages/account/my-profile/index.tsx
@@ -11,7 +11,7 @@ const AccountMyProfileEnglish: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <AccountMyProfile url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/account/my-visit-history/index.tsx
+++ b/src/pages/account/my-visit-history/index.tsx
@@ -11,7 +11,7 @@ const AccountMyHistoryEnglish: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <AccountMyHistory url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/account/share-folder/[folderId]/index.tsx
+++ b/src/pages/account/share-folder/[folderId]/index.tsx
@@ -15,7 +15,7 @@ const AccountSharedFolderEnglish: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <AccountSharedFolder url={url} folderId={folderId} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/alerts/index.tsx
+++ b/src/pages/admin/alerts/index.tsx
@@ -12,7 +12,7 @@ const AdminMaintenanceAlertsOverviewEnglish: FC<DefaultSeoInfo> = ({ url }) => {
 	return <AdminMaintenanceAlertsOverview url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/bezoekersruimtesbeheer/actieve-bezoekers.tsx
+++ b/src/pages/admin/bezoekersruimtesbeheer/actieve-bezoekers.tsx
@@ -11,7 +11,7 @@ const AdminActiveVisitorsDutch: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <AdminActiveVisitors url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/bezoekersruimtesbeheer/bezoekersruimtes/[slug]/index.tsx
+++ b/src/pages/admin/bezoekersruimtesbeheer/bezoekersruimtes/[slug]/index.tsx
@@ -11,7 +11,7 @@ const VisitorSpaceEditDutch: FC<DefaultSeoInfo> = ({ url }) => {
 	return <AdminVisitorSpaceEdit url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/bezoekersruimtesbeheer/bezoekersruimtes/index.tsx
+++ b/src/pages/admin/bezoekersruimtesbeheer/bezoekersruimtes/index.tsx
@@ -11,7 +11,7 @@ const VisitorSpacesOverviewDutch: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <AdminVisitorSpacesOverview url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/bezoekersruimtesbeheer/bezoekersruimtes/maak/index.tsx
+++ b/src/pages/admin/bezoekersruimtesbeheer/bezoekersruimtes/maak/index.tsx
@@ -11,7 +11,7 @@ const VisitorSpaceCreateDutch: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <AdminVisitorSpaceCreate url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/bezoekersruimtesbeheer/toegangsaanvragen.tsx
+++ b/src/pages/admin/bezoekersruimtesbeheer/toegangsaanvragen.tsx
@@ -11,7 +11,7 @@ const AdminVisitRequestsDutch: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <AdminVisitRequests url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/content-page-labels/[id]/edit/index.tsx
+++ b/src/pages/admin/content-page-labels/[id]/edit/index.tsx
@@ -15,7 +15,7 @@ const ContentPageLabelsEditPageEnglish: NextPage<DefaultSeoInfo> = ({ url }) => 
 	return <ContentPageLabelsEditPage url={url} id={router.query.id as string} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/content-page-labels/[id]/index.tsx
+++ b/src/pages/admin/content-page-labels/[id]/index.tsx
@@ -12,7 +12,7 @@ const ContentPageLabelsDetailPageEnglish: NextPage<DefaultSeoInfo> = ({ url }) =
 	return <ContentPageLabelsDetailPage url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/content-page-labels/create/index.tsx
+++ b/src/pages/admin/content-page-labels/create/index.tsx
@@ -12,7 +12,7 @@ const ContentPageLabelsEditPageEnglish: NextPage<DefaultSeoInfo> = ({ url }) => 
 	return <ContentPageLabelsEditPage url={url} id={undefined} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/content-page-labels/index.tsx
+++ b/src/pages/admin/content-page-labels/index.tsx
@@ -12,7 +12,7 @@ export const ContentPageLabelsOverviewPageEnglish: NextPage<DefaultSeoInfo> = ({
 	return <ContentPageLabelsOverviewPage url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/content-pages/[id].tsx
+++ b/src/pages/admin/content-pages/[id].tsx
@@ -29,7 +29,7 @@ const ContentPageDetailPageEnglish: NextPage<DefaultSeoInfo & UserProps> = ({
 	);
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/content-pages/[id]/edit/index.tsx
+++ b/src/pages/admin/content-pages/[id]/edit/index.tsx
@@ -16,7 +16,7 @@ const ContentPageEditPageEnglish: NextPage<DefaultSeoInfo & UserProps> = ({ url,
 	return <ContentPageEditPage url={url} commonUser={commonUser} id={router.query.id as string} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/content-pages/create.tsx
+++ b/src/pages/admin/content-pages/create.tsx
@@ -20,7 +20,7 @@ const ContentPageEditPageEnglish: NextPage<DefaultSeoInfo & UserProps> = ({ url,
 	);
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/content-pages/index.tsx
+++ b/src/pages/admin/content-pages/index.tsx
@@ -16,7 +16,7 @@ const ContentPageOverviewPageEnglish: NextPage<DefaultSeoInfo & UserProps> = ({
 	return <ContentPageOverviewPage url={url} commonUser={commonUser} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/content-pagina-labels/[id]/bewerk/index.tsx
+++ b/src/pages/admin/content-pagina-labels/[id]/bewerk/index.tsx
@@ -15,7 +15,7 @@ const ContentPageLabelsEditPageDutch: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <ContentPageLabelsEditPage url={url} id={router.query.id as string} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/content-pagina-labels/[id]/index.tsx
+++ b/src/pages/admin/content-pagina-labels/[id]/index.tsx
@@ -12,7 +12,7 @@ const ContentPageLabelsDetailPageDutch: NextPage<DefaultSeoInfo> = ({ url }) => 
 	return <ContentPageLabelsDetailPage url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/content-pagina-labels/index.tsx
+++ b/src/pages/admin/content-pagina-labels/index.tsx
@@ -12,7 +12,7 @@ export const ContentPageLabelsOverviewPageDutch: NextPage<DefaultSeoInfo> = ({ u
 	return <ContentPageLabelsOverviewPage url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/content-pagina-labels/maak/index.tsx
+++ b/src/pages/admin/content-pagina-labels/maak/index.tsx
@@ -12,7 +12,7 @@ const ContentPageLabelsEditPageDutch: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <ContentPageLabelsEditPage url={url} id={undefined} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/content-paginas/[id].tsx
+++ b/src/pages/admin/content-paginas/[id].tsx
@@ -26,7 +26,7 @@ const ContentPageDetailPageDutch: NextPage<DefaultSeoInfo & UserProps> = ({ url,
 	);
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/content-paginas/[id]/bewerk/index.tsx
+++ b/src/pages/admin/content-paginas/[id]/bewerk/index.tsx
@@ -16,7 +16,7 @@ const ContentPageEditPageDutch: NextPage<DefaultSeoInfo & UserProps> = ({ url, c
 	return <ContentPageEditPage url={url} commonUser={commonUser} id={router.query.id as string} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/content-paginas/index.tsx
+++ b/src/pages/admin/content-paginas/index.tsx
@@ -16,7 +16,7 @@ const ContentPageOverviewPageDutch: NextPage<DefaultSeoInfo & UserProps> = ({
 	return <ContentPageOverviewPage url={url} commonUser={commonUser} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/content-paginas/maak.tsx
+++ b/src/pages/admin/content-paginas/maak.tsx
@@ -13,7 +13,7 @@ const ContentPageEditPageDutch: NextPage<DefaultSeoInfo & UserProps> = ({ url, c
 	return <ContentPageEditPage url={url} commonUser={commonUser} id={undefined} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/gebruikersbeheer/gebruikers/index.tsx
+++ b/src/pages/admin/gebruikersbeheer/gebruikers/index.tsx
@@ -13,7 +13,7 @@ const UsersOverviewPageDutch: NextPage<DefaultSeoInfo & UserProps> = ({ url, com
 	return <UsersOverviewPage url={url} commonUser={commonUser} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/gebruikersbeheer/permissies/index.tsx
+++ b/src/pages/admin/gebruikersbeheer/permissies/index.tsx
@@ -12,7 +12,7 @@ const PermissionsOverviewDutch: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <PermissionsOverview url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/materiaalaanvragen/index.tsx
+++ b/src/pages/admin/materiaalaanvragen/index.tsx
@@ -11,7 +11,7 @@ const AdminMaterialRequestsDutch: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <AdminMaterialRequests url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/materialrequests/index.tsx
+++ b/src/pages/admin/materialrequests/index.tsx
@@ -11,7 +11,7 @@ const AdminMaterialRequestsEnglish: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <AdminMaterialRequests url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/meldingen/index.tsx
+++ b/src/pages/admin/meldingen/index.tsx
@@ -12,7 +12,7 @@ const AdminMaintenanceAlertsOverviewDutch: FC<DefaultSeoInfo> = ({ url }) => {
 	return <AdminMaintenanceAlertsOverview url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/navigatie/[navigationBarId]/[navigationItemId]/bewerk/index.tsx
+++ b/src/pages/admin/navigatie/[navigationBarId]/[navigationItemId]/bewerk/index.tsx
@@ -21,7 +21,7 @@ const AdminNavigationItemEditPageDutch: NextPage<DefaultSeoInfo> = ({ url }) => 
 	);
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/navigatie/[navigationBarId]/index.tsx
+++ b/src/pages/admin/navigatie/[navigationBarId]/index.tsx
@@ -20,7 +20,7 @@ const AdminNavigationBarDetailPageDutch: NextPage<DefaultSeoInfo> = ({ url }) =>
 	);
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/navigatie/[navigationBarId]/maak/index.tsx
+++ b/src/pages/admin/navigatie/[navigationBarId]/maak/index.tsx
@@ -20,7 +20,7 @@ const AdminNavigationItemCreatePageDutch: NextPage<DefaultSeoInfo> = ({ url }) =
 	);
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/navigatie/index.tsx
+++ b/src/pages/admin/navigatie/index.tsx
@@ -12,7 +12,7 @@ const AdminNavigationOverviewDutch: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <AdminNavigationOverview url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/navigatie/maak/index.tsx
+++ b/src/pages/admin/navigatie/maak/index.tsx
@@ -20,7 +20,7 @@ const AdminNavigationItemCreatePageDutch: NextPage<DefaultSeoInfo> = ({ url }) =
 	);
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/navigation/[navigationBarId]/[navigationItemId]/bewerk/index.tsx
+++ b/src/pages/admin/navigation/[navigationBarId]/[navigationItemId]/bewerk/index.tsx
@@ -21,7 +21,7 @@ const AdminNavigationItemEditPageEnglish: NextPage<DefaultSeoInfo> = ({ url }) =
 	);
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/navigation/[navigationBarId]/index.tsx
+++ b/src/pages/admin/navigation/[navigationBarId]/index.tsx
@@ -20,7 +20,7 @@ const AdminNavigationBarDetailPageEnglish: NextPage<DefaultSeoInfo> = ({ url }) 
 	);
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/navigation/[navigationBarId]/maak/index.tsx
+++ b/src/pages/admin/navigation/[navigationBarId]/maak/index.tsx
@@ -20,7 +20,7 @@ const AdminNavigationItemCreatePageEnglish: NextPage<DefaultSeoInfo> = ({ url })
 	);
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/navigation/index.tsx
+++ b/src/pages/admin/navigation/index.tsx
@@ -12,7 +12,7 @@ const AdminNavigationOverviewEnglish: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <AdminNavigationOverview url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/navigation/maak/index.tsx
+++ b/src/pages/admin/navigation/maak/index.tsx
@@ -20,7 +20,7 @@ const AdminNavigationItemCreatePageEnglish: NextPage<DefaultSeoInfo> = ({ url })
 	);
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/translations/index.tsx
+++ b/src/pages/admin/translations/index.tsx
@@ -12,7 +12,7 @@ const AdminTranslationsOverviewEnglish: NextPage<DefaultSeoInfo> = ({ url }) => 
 	return <AdminTranslationsOverview url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/usermanagement/permissions/index.tsx
+++ b/src/pages/admin/usermanagement/permissions/index.tsx
@@ -12,7 +12,7 @@ const PermissionsOverviewEnglish: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <PermissionsOverview url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/usermanagement/users/index.tsx
+++ b/src/pages/admin/usermanagement/users/index.tsx
@@ -13,7 +13,7 @@ const UsersOverviewPageEnglish: NextPage<DefaultSeoInfo & UserProps> = ({ url, c
 	return <UsersOverviewPage url={url} commonUser={commonUser} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/vertalingen/index.tsx
+++ b/src/pages/admin/vertalingen/index.tsx
@@ -12,7 +12,7 @@ const AdminTranslationsOverviewDutch: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <AdminTranslationsOverview url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/visitorspacesmanagement/active-visitors.tsx
+++ b/src/pages/admin/visitorspacesmanagement/active-visitors.tsx
@@ -11,7 +11,7 @@ const AdminActiveVisitorsEnglish: FC<DefaultSeoInfo> = ({ url }) => {
 	return <AdminActiveVisitors url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/visitorspacesmanagement/visitorspaces/[slug]/index.tsx
+++ b/src/pages/admin/visitorspacesmanagement/visitorspaces/[slug]/index.tsx
@@ -11,7 +11,7 @@ const VisitorSpaceEditEnglish: FC<DefaultSeoInfo> = ({ url }) => {
 	return <AdminVisitorSpaceEdit url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/visitorspacesmanagement/visitorspaces/create/index.tsx
+++ b/src/pages/admin/visitorspacesmanagement/visitorspaces/create/index.tsx
@@ -11,7 +11,7 @@ const VisitorSpaceCreateEnglish: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <AdminVisitorSpaceCreate url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/visitorspacesmanagement/visitorspaces/index.tsx
+++ b/src/pages/admin/visitorspacesmanagement/visitorspaces/index.tsx
@@ -11,7 +11,7 @@ const VisitorSpacesOverviewEnglish: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <AdminVisitorSpacesOverview url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/admin/visitorspacesmanagement/visitrequests.tsx
+++ b/src/pages/admin/visitorspacesmanagement/visitrequests.tsx
@@ -11,7 +11,7 @@ const AdminVisitRequestsEnglish: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <AdminVisitRequests url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/beheer/bezoekers.tsx
+++ b/src/pages/beheer/bezoekers.tsx
@@ -11,7 +11,7 @@ const CpAdminVisitorsPageDutch: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <CpAdminVisitorsPage url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/beheer/instellingen.tsx
+++ b/src/pages/beheer/instellingen.tsx
@@ -11,7 +11,7 @@ const CpAdminSettingsPageDutch: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <CpAdminSettingsPage url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/beheer/materiaalaanvragen.tsx
+++ b/src/pages/beheer/materiaalaanvragen.tsx
@@ -11,7 +11,7 @@ const CpAdminMaterialRequestsPageDutch: NextPage<DefaultSeoInfo> = ({ url }) => 
 	return <CpAdminMaterialRequests url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/beheer/toegangsaanvragen.tsx
+++ b/src/pages/beheer/toegangsaanvragen.tsx
@@ -11,7 +11,7 @@ const CpAdminVisitorRequestsPageDutch: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <CpAdminVisitRequestsPage url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/bezoek/[slug]/index.tsx
+++ b/src/pages/bezoek/[slug]/index.tsx
@@ -18,7 +18,7 @@ const VisitPageDutch: NextPage<VisitPageProps> = (seo) => {
 	return <VisitPage {...seo} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<VisitPageProps>> {
 	let space: VisitorSpaceInfo | null = null;

--- a/src/pages/bezoek/[slug]/toegang-aangevraagd/index.tsx
+++ b/src/pages/bezoek/[slug]/toegang-aangevraagd/index.tsx
@@ -19,7 +19,7 @@ const VisitRequestedPageDutch: NextPage<VisitRequestedPageProps> = ({ name, desc
 	return <VisitRequestedPage name={name} description={description} url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<VisitRequestedPageProps>> {
 	let space: VisitorSpaceInfo | null = null;

--- a/src/pages/bezoek/index.tsx
+++ b/src/pages/bezoek/index.tsx
@@ -9,7 +9,7 @@ const VisitorSpacesHomeDutch: NextPage<DefaultSeoInfo> = (seo) => {
 	return <VisitorSpacesHomePage {...seo} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/cookie-policy/index.tsx
+++ b/src/pages/cookie-policy/index.tsx
@@ -11,7 +11,7 @@ const CookiePolicyEnglish: NextPage<DefaultSeoInfo> = (seo) => {
 	return <CookiePolicy {...seo} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/cookiebeleid/index.tsx
+++ b/src/pages/cookiebeleid/index.tsx
@@ -11,7 +11,7 @@ const CookiePolicyDutch: NextPage<DefaultSeoInfo> = (seo) => {
 	return <CookiePolicy {...seo} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/gebruiksvoorwaarden/index.tsx
+++ b/src/pages/gebruiksvoorwaarden/index.tsx
@@ -13,7 +13,7 @@ const UserConditionsDutch: NextPage<DefaultSeoInfo & UserProps> = ({ commonUser,
 	return <UserConditions commonUser={commonUser} url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -22,13 +22,7 @@ import withUser, { UserProps } from '@shared/hooks/with-user';
 import { DefaultSeoInfo } from '@shared/types/seo';
 import { Locale } from '@shared/utils';
 
-type HomepageProps = {
-	title: string | null;
-	description: string | null;
-	image: string | null;
-} & DefaultSeoInfo;
-
-const Homepage: NextPage<HomepageProps & UserProps> = ({
+const Homepage: NextPage<DefaultSeoInfo & UserProps> = ({
 	title,
 	description,
 	image,
@@ -78,7 +72,7 @@ const Homepage: NextPage<HomepageProps & UserProps> = ({
 	return (
 		<VisitorLayout>
 			{renderOgTags(
-				title,
+				title || null,
 				description ||
 					contentPageInfo?.seoDescription ||
 					contentPageInfo?.description ||
@@ -94,7 +88,7 @@ const Homepage: NextPage<HomepageProps & UserProps> = ({
 
 export async function getStaticProps(
 	context: GetServerSidePropsContext
-): Promise<GetServerSidePropsResult<HomepageProps>> {
+): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	let title: string | null = null;
 	let description: string | null = null;
 	let image: string | null = null;
@@ -113,9 +107,6 @@ export async function getStaticProps(
 		});
 	}
 
-	const defaultProps: GetServerSidePropsResult<DefaultSeoInfo> =
-		await getDefaultStaticProps(context);
-
 	const queryClient = new QueryClient();
 
 	const path = KNOWN_STATIC_ROUTES.Home;
@@ -127,15 +118,7 @@ export async function getStaticProps(
 
 	const dehydratedState = dehydrate(queryClient);
 
-	return {
-		props: {
-			...(defaultProps as { props: DefaultSeoInfo }).props,
-			title,
-			description,
-			image,
-			dehydratedState,
-		},
-	};
+	return getDefaultStaticProps(context, dehydratedState, title, description, image);
 }
 
-export default withUser(withAuth(Homepage as ComponentType, false)) as FC<HomepageProps>;
+export default withUser(withAuth(Homepage as ComponentType, false)) as FC<DefaultSeoInfo>;

--- a/src/pages/logout/index.tsx
+++ b/src/pages/logout/index.tsx
@@ -15,7 +15,7 @@ const Logout: NextPage = () => {
 	return <Loading fullscreen owner="uitloggen" />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/management/material-requests.tsx
+++ b/src/pages/management/material-requests.tsx
@@ -11,7 +11,7 @@ const CpAdminMaterialRequestsPageEnglish: NextPage<DefaultSeoInfo> = ({ url }) =
 	return <CpAdminMaterialRequests url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/management/settings.tsx
+++ b/src/pages/management/settings.tsx
@@ -11,7 +11,7 @@ const CpAdminSettingsPageEnglish: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <CpAdminSettingsPage url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/management/visit-requests.tsx
+++ b/src/pages/management/visit-requests.tsx
@@ -11,7 +11,7 @@ const CpAdminVisitorRequestsPageEnglish: NextPage<DefaultSeoInfo> = ({ url }) =>
 	return <CpAdminVisitRequestsPage url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/management/visitors.tsx
+++ b/src/pages/management/visitors.tsx
@@ -11,7 +11,7 @@ const CpAdminVisitorsPageEnglish: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <CpAdminVisitorsPage url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/newsletter/confirmed/index.tsx
+++ b/src/pages/newsletter/confirmed/index.tsx
@@ -9,7 +9,7 @@ const NewsletterConfirmationEnglish: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <NewsletterConfirmation url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/newsletter/failed/index.tsx
+++ b/src/pages/newsletter/failed/index.tsx
@@ -10,7 +10,7 @@ const NewsletterFailedEnglish: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <NewsletterFailed url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/newsletter/index.tsx
+++ b/src/pages/newsletter/index.tsx
@@ -9,7 +9,7 @@ const NewsletterPageEnglish: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <NewsletterPage url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/nieuwsbrief/bevestiging/index.tsx
+++ b/src/pages/nieuwsbrief/bevestiging/index.tsx
@@ -9,7 +9,7 @@ const NewsletterConfirmationDutch: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <NewsletterConfirmation url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/nieuwsbrief/index.tsx
+++ b/src/pages/nieuwsbrief/index.tsx
@@ -9,7 +9,7 @@ const NewsletterPageDutch: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <NewsletterPage url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/nieuwsbrief/mislukt/index.tsx
+++ b/src/pages/nieuwsbrief/mislukt/index.tsx
@@ -10,7 +10,7 @@ const NewsletterFailedDutch: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <NewsletterFailed url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/openseadragon/index.tsx
+++ b/src/pages/openseadragon/index.tsx
@@ -139,7 +139,7 @@ import { EventsService, LogEventType } from '@shared/services/events-service';
 import { toastService } from '@shared/services/toast-service';
 import { selectFolders } from '@shared/store/ie-objects';
 import { selectBreadcrumbs, setShowAuthModal, setShowZendesk } from '@shared/store/ui';
-import { Breakpoints, IeObjectTypes, VisitorSpaceMediaType } from '@shared/types';
+import { Breakpoints, IeObjectTypes, SearchPageMediaType } from '@shared/types';
 import { DefaultSeoInfo } from '@shared/types/seo';
 import {
 	asDate,
@@ -157,7 +157,7 @@ import { ReportBlade } from '@visitor-space/components/reportBlade';
 import { useGetVisitorSpace } from '@visitor-space/hooks/get-visitor-space';
 import {
 	FILTER_LABEL_VALUE_DELIMITER,
-	VisitorSpaceFilterId,
+	SearchFilterId,
 	VisitorSpaceStatus,
 } from '@visitor-space/types';
 
@@ -504,7 +504,7 @@ const ObjectDetailPage: NextPage<ObjectDetailPageProps> = ({ title, description,
 		setMediaType(mediaInfo?.dctermsFormat as IeObjectTypes);
 
 		// Filter out peak files if type === video
-		if (mediaInfo?.dctermsFormat === VisitorSpaceMediaType.Video) {
+		if (mediaInfo?.dctermsFormat === SearchPageMediaType.Video) {
 			mediaInfo.representations = mediaInfo?.representations?.filter(
 				(object) => object.dctermsFormat !== 'peak'
 			);
@@ -1370,7 +1370,7 @@ const ObjectDetailPage: NextPage<ObjectDetailPageProps> = ({ title, description,
 									label: mediaInfo?.maintainerName,
 									to: isKiosk
 										? ROUTES_BY_LOCALE[locale].search
-										: `${ROUTES_BY_LOCALE[locale].search}?${VisitorSpaceFilterId.Maintainer}=${mediaInfo?.maintainerSlug}`,
+										: `${ROUTES_BY_LOCALE[locale].search}?${SearchFilterId.Maintainer}=${mediaInfo?.maintainerSlug}`,
 								},
 						  ]
 						: []),
@@ -1463,7 +1463,7 @@ const ObjectDetailPage: NextPage<ObjectDetailPageProps> = ({ title, description,
 									stringifyUrl({
 										url: `/${ROUTE_PARTS_BY_LOCALE[locale].search}`,
 										query: {
-											[VisitorSpaceFilterId.Maintainers]: [
+											[SearchFilterId.Maintainers]: [
 												`${maintainerId}${FILTER_LABEL_VALUE_DELIMITER}${maintainerName}`,
 											],
 										},
@@ -1996,7 +1996,7 @@ const ObjectDetailPage: NextPage<ObjectDetailPageProps> = ({ title, description,
 	);
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<ObjectDetailPageProps>> {
 	// let seoInfo: SeoInfo | null = null;

--- a/src/pages/search/[slug]/[ie]/[name]/index.tsx
+++ b/src/pages/search/[slug]/[ie]/[name]/index.tsx
@@ -17,7 +17,7 @@ const ObjectDetailPageEnglish: NextPage<ObjectDetailPageProps> = ({ title, descr
 	return <ObjectDetailPage title={title} description={description} url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<ObjectDetailPageProps>> {
 	let seoInfo: SeoInfo | null = null;

--- a/src/pages/search/[slug]/[ie]/index.tsx
+++ b/src/pages/search/[slug]/[ie]/index.tsx
@@ -13,7 +13,7 @@ const IeObjectWithoutObjectNamePageEnglish: NextPage<DefaultSeoInfo> = ({ url })
 	return <IeObjectWithoutObjectNamePage url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/search/[slug]/index.tsx
+++ b/src/pages/search/[slug]/index.tsx
@@ -9,7 +9,7 @@ const MaintainerSearchPageEnglish: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <MaintainerSearchPage url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,21 +1,41 @@
+import { dehydrate, QueryClient } from '@tanstack/react-query';
 import { GetServerSidePropsContext, GetServerSidePropsResult, NextPage } from 'next';
 import { ComponentType } from 'react';
 
 import { withAuth } from '@auth/wrappers/with-auth';
+import { makeServerSideRequestGetIeObjects } from '@ie-objects/hooks/get-ie-objects';
 import SearchPage from '@modules/search/SearchPage';
 import { getDefaultStaticProps } from '@shared/helpers/get-default-server-side-props';
 import { DefaultSeoInfo } from '@shared/types/seo';
 
 type SearchPageProps = DefaultSeoInfo;
 
-const SearchPageEnglish: NextPage<SearchPageProps> = ({ url }) => {
-	return <SearchPage url={url} />;
+const SearchPageEnglish: NextPage<SearchPageProps> = ({
+	url,
+	title,
+	description,
+	image,
+	dehydratedState,
+}) => {
+	return (
+		<SearchPage
+			url={url}
+			title={title}
+			description={description}
+			image={image}
+			dehydratedState={dehydratedState}
+		/>
+	);
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
-	return getDefaultStaticProps(context);
+	const queryClient = new QueryClient();
+	await makeServerSideRequestGetIeObjects(queryClient);
+	const dehydratedState = dehydrate(queryClient);
+
+	return getDefaultStaticProps(context, dehydratedState);
 }
 
 export default withAuth(SearchPageEnglish as ComponentType, false);

--- a/src/pages/uitloggen/index.tsx
+++ b/src/pages/uitloggen/index.tsx
@@ -15,7 +15,7 @@ const Logout: NextPage = () => {
 	return <Loading fullscreen owner="uitloggen" />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/user-conditions/index.tsx
+++ b/src/pages/user-conditions/index.tsx
@@ -13,7 +13,7 @@ const UserConditionsEnglish: NextPage<DefaultSeoInfo & UserProps> = ({ commonUse
 	return <UserConditions commonUser={commonUser} url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/visit/[slug]/access-requested/index.tsx
+++ b/src/pages/visit/[slug]/access-requested/index.tsx
@@ -23,7 +23,7 @@ const VisitRequestedPageEnglish: NextPage<VisitRequestedPageProps> = ({
 	return <VisitRequestedPage name={name} description={description} url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<VisitRequestedPageProps>> {
 	let space: VisitorSpaceInfo | null = null;

--- a/src/pages/visit/[slug]/index.tsx
+++ b/src/pages/visit/[slug]/index.tsx
@@ -18,7 +18,7 @@ const VisitPageEnglish: NextPage<VisitPageProps> = (seo) => {
 	return <VisitPage {...seo} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<VisitPageProps>> {
 	let space: VisitorSpaceInfo | null = null;

--- a/src/pages/visit/index.tsx
+++ b/src/pages/visit/index.tsx
@@ -9,7 +9,7 @@ const VisitorSpacesHomeEnglish: NextPage<DefaultSeoInfo> = (seo) => {
 	return <VisitorSpacesHomePage {...seo} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/zoeken/[slug]/[ie]/[name]/index.tsx
+++ b/src/pages/zoeken/[slug]/[ie]/[name]/index.tsx
@@ -17,7 +17,7 @@ const ObjectDetailPageDutch: NextPage<ObjectDetailPageProps> = ({ title, descrip
 	return <ObjectDetailPage title={title} description={description} url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<ObjectDetailPageProps>> {
 	let seoInfo: SeoInfo | null = null;

--- a/src/pages/zoeken/[slug]/[ie]/index.tsx
+++ b/src/pages/zoeken/[slug]/[ie]/index.tsx
@@ -13,7 +13,7 @@ const IeObjectWithoutObjectNamePageDutch: NextPage<DefaultSeoInfo> = ({ url }) =
 	return <IeObjectWithoutObjectNamePage url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/zoeken/[slug]/index.tsx
+++ b/src/pages/zoeken/[slug]/index.tsx
@@ -9,7 +9,7 @@ const MaintainerSearchPageDutch: NextPage<DefaultSeoInfo> = ({ url }) => {
 	return <MaintainerSearchPage url={url} />;
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
 	return getDefaultStaticProps(context);

--- a/src/pages/zoeken/index.tsx
+++ b/src/pages/zoeken/index.tsx
@@ -1,21 +1,41 @@
+import { dehydrate, QueryClient } from '@tanstack/react-query';
 import { GetServerSidePropsContext, GetServerSidePropsResult, NextPage } from 'next';
 import { ComponentType } from 'react';
 
 import { withAuth } from '@auth/wrappers/with-auth';
+import { makeServerSideRequestGetIeObjects } from '@ie-objects/hooks/get-ie-objects';
 import SearchPage from '@modules/search/SearchPage';
 import { getDefaultStaticProps } from '@shared/helpers/get-default-server-side-props';
 import { DefaultSeoInfo } from '@shared/types/seo';
 
 type SearchPageProps = DefaultSeoInfo;
 
-const SearchPageDutch: NextPage<SearchPageProps> = ({ url }) => {
-	return <SearchPage url={url} />;
+const SearchPageDutch: NextPage<SearchPageProps> = ({
+	url,
+	title,
+	description,
+	image,
+	dehydratedState,
+}) => {
+	return (
+		<SearchPage
+			url={url}
+			title={title}
+			description={description}
+			image={image}
+			dehydratedState={dehydratedState}
+		/>
+	);
 };
 
-export async function getServerSideProps(
+export async function getStaticProps(
 	context: GetServerSidePropsContext
 ): Promise<GetServerSidePropsResult<DefaultSeoInfo>> {
-	return getDefaultStaticProps(context);
+	const queryClient = new QueryClient();
+	await makeServerSideRequestGetIeObjects(queryClient);
+	const dehydratedState = dehydrate(queryClient);
+
+	return getDefaultStaticProps(context, dehydratedState);
 }
 
 export default withAuth(SearchPageDutch as ComponentType, false);


### PR DESCRIPTION
https://meemoo.atlassian.net/issues/ARC-2197

requires admin-core pr: https://github.com/viaacode/react-admin-core-module/pull/255

Main changes:
* src/pages/index.tsx
* src/modules/content-page/hooks/get-content-page.ts
* src/modules/visitor-space/components/FilterMenu/FilterMenu.tsx

Other changes:
* use getStaticProps instead of getServerSideProps (more efficient caching)
* rename some enums from the old visitor tool site to the new archief v2 site

![image](https://github.com/viaacode/hetarchief-client/assets/1710840/66d3fc19-7e75-4e67-b4f6-d479ece02cf3)
![image](https://github.com/viaacode/hetarchief-client/assets/1710840/7e46ac67-44a1-41c5-a6bc-55171b105671)
