### PR TITLE
ARC-2417 Fix QAS build

### DIFF
--- a/openshift/Jenkinsfile
+++ b/openshift/Jenkinsfile
@@ -80,7 +80,7 @@ pipeline {
 					buildingTag()
 				}
 				not {
-					branch 'develop'
+					anyOf { branch 'master'; branch 'develop' }
 				}
 
 			}
@@ -204,13 +204,18 @@ pipeline {
 		// 		} //end script
 		// 	}
 		// }
-		stage('Deploy QAS') {
+		stage('Build and Deploy QAS') {
 			when {
 				anyOf { branch 'master'; branch 'main' }
 			}
 			steps {
 				container('oc') {
-					tagNewImage('qas')
+					script {
+						sh """#!/bin/bash
+                            oc project $OC_PROJECT
+                            oc start-build --follow=true --wait=true client-qas
+                        """
+					}
 				}
 			}
 			post {


### PR DESCRIPTION
Every environment should be build using specific parameters. This is to ensure the server-side rendering uses the correct information when pre-rendering components. Change the QAS stage to use the specific client-qas build config.