### PR TITLE
fix(performance): add priority to waveform svg image

### DIFF
--- a/src/modules/shared/components/MediaCard/MediaCard.tsx
+++ b/src/modules/shared/components/MediaCard/MediaCard.tsx
@@ -291,7 +291,7 @@ const MediaCard: FC<MediaCardProps> = ({
 					styles[`c-media-card__header-wrapper--${view}`]
 				)}
 			>
-				<Image src={imgPath} alt={''} unoptimized={true} layout="fill" />
+				<Image src={imgPath} alt={''} unoptimized={true} layout="fill" priority />
 				{!isNil(icon) && (
 					<>
 						<div className={clsx(styles['c-media-card__header-icon'])}>


### PR DESCRIPTION
on the search page:
http://localhost:3200/zoeken

You would get the console warning:
```
utils.js:90 Image with src "/images/waveform.svg" was detected as the Largest Contentful Paint (LCP). Please add the "priority" property if this image is above the fold.
Read more: https://nextjs.org/docs/api-reference/next/image#priority
```

![image](https://github.com/user-attachments/assets/55a5e790-a436-463e-958d-8f62adacde08)


after this PR the warning is gone:
![image](https://github.com/user-attachments/assets/ed70602c-6164-41a8-86f8-f2438180e2ae)
