### PR TITLE
feat(ARC-2419): use alto json files instead of larger xml files

### DIFF
--- a/src/modules/ie-objects/hooks/get-alto-json-file-content.ts
+++ b/src/modules/ie-objects/hooks/get-alto-json-file-content.ts
@@ -1,5 +1,6 @@
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
+import { IeObjectsService } from '@ie-objects/services';
 import { type SimplifiedAlto } from '@iiif-viewer/IiifViewer.types';
 import { QUERY_KEYS } from '@shared/const/query-keys';
 
@@ -20,8 +21,7 @@ export const useGetAltoJsonFileContent = (
 				return convertAltoXmlFileUrlToSimplifiedJson(altoJsonUrl);
 			}
 
-			const response = await fetch(altoJsonUrl);
-			return await response.json();
+			return await IeObjectsService.getAltoJsonFile(altoJsonUrl);
 		},
 		{
 			keepPreviousData: true,

--- a/src/modules/ie-objects/ie-objects.consts.tsx
+++ b/src/modules/ie-objects/ie-objects.consts.tsx
@@ -555,13 +555,10 @@ export const GET_METADATA_FIELDS = (
 			title: tText('modules/ie-objects/ie-objects___afmetingen-in-cm'),
 			data:
 				(mediaInfo?.width
-					? tText('modules/ie-objects/ie-objects___breedte') + mediaInfo?.width + 'cm'
+					? tText('modules/ie-objects/ie-objects___breedte') + mediaInfo?.width
 					: '') +
 					(mediaInfo?.height
-						? ' ' +
-						  tText('modules/ie-objects/ie-objects___hoogte') +
-						  mediaInfo?.height +
-						  'cm'
+						? ' ' + tText('modules/ie-objects/ie-objects___hoogte') + mediaInfo?.height
 						: '') || null,
 		},
 		{

--- a/src/modules/ie-objects/services/ie-objects/ie-objects.service.const.ts
+++ b/src/modules/ie-objects/services/ie-objects/ie-objects.service.const.ts
@@ -3,6 +3,6 @@ export const NEWSPAPERS_SERVICE_BASE_URL = 'newspapers';
 export const IE_OBJECT_SERVICE_TICKET_URL = 'player-ticket';
 export const IE_OBJECT_SERVICE_SEO_URL = 'seo';
 export const IE_OBJECTS_SERVICE_EXPORT = 'export';
-export const IE_OBJECTS_SERVICE_RELATED_COUNT = 'related/count';
 export const IE_OBJECTS_SERVICE_SIMILAR = 'similar';
 export const IO_OBJECTS_SERVICE_RELATED = 'related';
+export const IO_OBJECTS_SERVICE_DOWNLOAD_ALTO_JSON = 'alto-json';

--- a/src/modules/ie-objects/services/ie-objects/ie-objects.service.ts
+++ b/src/modules/ie-objects/services/ie-objects/ie-objects.service.ts
@@ -7,6 +7,7 @@ import {
 	type RelatedIeObjects,
 } from '@ie-objects/ie-objects.types';
 import { type SeoInfo } from '@ie-objects/services/ie-objects/ie-objects.service.types';
+import { type SimplifiedAlto } from '@iiif-viewer/IiifViewer.types';
 import { ApiService } from '@shared/services/api-service';
 import { type SortObject } from '@shared/types';
 import { type GetIeObjectsResponse } from '@shared/types/api';
@@ -23,6 +24,7 @@ import {
 	IE_OBJECT_SERVICE_TICKET_URL,
 	IE_OBJECTS_SERVICE_BASE_URL,
 	IE_OBJECTS_SERVICE_SIMILAR,
+	IO_OBJECTS_SERVICE_DOWNLOAD_ALTO_JSON,
 	IO_OBJECTS_SERVICE_RELATED,
 } from './ie-objects.service.const';
 
@@ -141,6 +143,17 @@ export class IeObjectsService {
 				stringifyUrl({
 					url: `${IE_OBJECTS_SERVICE_BASE_URL}/${IO_OBJECTS_SERVICE_RELATED}`,
 					query: { ieObjectIri, parentIeObjectIri },
+				})
+			)
+			.json();
+	}
+
+	public static async getAltoJsonFile(altoJsonUrl: string): Promise<SimplifiedAlto> {
+		return await ApiService.getApi()
+			.get(
+				stringifyUrl({
+					url: `${IE_OBJECTS_SERVICE_BASE_URL}/${IO_OBJECTS_SERVICE_DOWNLOAD_ALTO_JSON}`,
+					query: { altoJsonUrl },
 				})
 			)
 			.json();


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-2419

proxy PR: https://github.com/viaacode/hetarchief-proxy/pull/509

also:
* remove 'cm' from dimension units since they already contain 'cm'
* download the alto file through the proxy, since we otherwise have cors issues since the test alto files are on the INT asset service

![image](https://github.com/user-attachments/assets/afe2e739-641e-4689-80c9-39f425316023)
