### PR TITLE
fix(ARC-2506): scroll to advanced filter when filter menu is collapsed

### DIFF
--- a/src/modules/search/SearchPage.tsx
+++ b/src/modules/search/SearchPage.tsx
@@ -773,14 +773,19 @@ const SearchPage: FC<DefaultSeoInfo> = ({ url }) => {
 	}, [isKioskUser, isGlobalArchive, locale, searchResults?.items, searchResults?.searchTerms]);
 
 	const openAndScrollToAdvancedFilters = () => {
+		setFilterMenuOpen(true);
 		setQuery({ filter: SearchFilterId.Advanced });
-		document
-			.getElementById(`c-filter-menu__option__${SearchFilterId.Advanced}`)
-			?.scrollIntoView({
-				behavior: 'smooth',
-				block: 'center',
-				inline: 'center',
-			});
+
+		// Wait for filter menu to open before scrolling to the advanced filters
+		setTimeout(() => {
+			document
+				.getElementById(`c-filter-menu__option__${SearchFilterId.Advanced}`)
+				?.scrollIntoView({
+					behavior: 'smooth',
+					block: 'center',
+					inline: 'center',
+				});
+		}, 0);
 	};
 
 	/**


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-2506



https://github.com/user-attachments/assets/2ae1a49a-2ee9-4614-bf07-863583973259

