### PR TITLE
ARC-2536 Fix INT (Docker image) build

### DIFF
--- a/openshift/Jenkinsfile
+++ b/openshift/Jenkinsfile
@@ -105,6 +105,7 @@ pipeline {
 						sh '''#!/bin/bash
 							oc -n $OC_PROJECT patch "bc/${APP_NAME}-int" -p "{\\"spec\\":{\\"source\\":{\\"git\\":{\\"ref\\":\\"${GIT_SHORT_COMMIT}\\"}}}}"
 							oc -n $OC_PROJECT patch "bc/${APP_NAME}-int" -p "{\\"metadata\\":{\\"annotations\\":{\\"ref\\":\\"${BRANCH_NAME}\\"}}}"
+							oc -n $OC_PROJECT patch "bc/${APP_NAME}-int" -p "{\\"metadata\\":{\\"annotations\\":{\\"shortcommit\\":\\"${GIT_SHORT_COMMIT}\\"}}}"
                         '''
 					}
 					startOpenShiftBuild('int', '$APP_NAME:${BRANCH_NAME}')
@@ -217,7 +218,8 @@ pipeline {
 					script {
 						sh '''#!/bin/bash
 							oc -n $OC_PROJECT patch "bc/${APP_NAME}-prd" -p "{\\"spec\\":{\\"source\\":{\\"git\\":{\\"ref\\":\\"${IMAGE_TAG}\\"}}}}"
-							oc -n $OC_PROJECT patch "bc/${APP_NAME}-prd" -p "{\\"metadata\\":{\\"annotations\\":{\\"ref\\":\\"${IMAGE_TAG}\\"}}}"							
+							oc -n $OC_PROJECT patch "bc/${APP_NAME}-prd" -p "{\\"metadata\\":{\\"annotations\\":{\\"ref\\":\\"${IMAGE_TAG}\\"}}}"
+							oc -n $OC_PROJECT patch "bc/${APP_NAME}-prd" -p "{\\"metadata\\":{\\"annotations\\":{\\"shortcommit\\":\\"${GIT_SHORT_COMMIT}\\"}}}"
                         '''
 					}
 					startOpenShiftBuild('prd', '${IMAGE_TAG}')

--- a/openshift/Jenkinsfile
+++ b/openshift/Jenkinsfile
@@ -290,7 +290,7 @@ void startOpenShiftBuild(String environment, String dockerTag) {
 		oc project $OC_PROJECT
 		oc start-build --follow=true --wait=true $APP_NAME-${environment}
 		# Check the status of the rollout
-		oc rollout status deployment/$APP_NAME-${environment} --watch=true --timeout=10m
+		oc rollout status deployment/$APP_NAME-${environment} --watch=true --timeout=20m
 
 		# Tag with the revision for rollback purposes
 		oc tag $APP_NAME:${environment} $APP_NAME:${dockerTag}

--- a/openshift/Jenkinsfile
+++ b/openshift/Jenkinsfile
@@ -104,7 +104,7 @@ pipeline {
 					script {
 						sh '''#!/bin/bash
 							oc -n $OC_PROJECT patch "bc/${APP_NAME}-int" -p "{\\"spec\\":{\\"source\\":{\\"git\\":{\\"ref\\":\\"${GIT_SHORT_COMMIT}\\"}}}}"
-							oc -n $OC_PROJECT patch "bc/${APP_NAME}-int" -p "{\\"metadata\\":{\\"annotations\\":{\\"ref\\":{\\"PR-${GITHUB_PR_NUMBER}\\"}}}"
+							oc -n $OC_PROJECT patch "bc/${APP_NAME}-int" -p "{\\"metadata\\":{\\"annotations\\":{\\"ref\\":\\"PR-${GITHUB_PR_NUMBER}\\"}}}"
                         '''
 					}
 					startOpenShiftBuild('int', '$APP_NAME:PR-${GITHUB_PR_NUMBER}')
@@ -217,7 +217,7 @@ pipeline {
 					script {
 						sh '''#!/bin/bash
 							oc -n $OC_PROJECT patch "bc/${APP_NAME}-prd" -p "{\\"spec\\":{\\"source\\":{\\"git\\":{\\"ref\\":\\"${IMAGE_TAG}\\"}}}}"
-							oc -n $OC_PROJECT patch "bc/${APP_NAME}-prd" -p "{\\"metadata\\":{\\"annotations\\":{\\"ref\\":{\\"${IMAGE_TAG}\\"}}}"							
+							oc -n $OC_PROJECT patch "bc/${APP_NAME}-prd" -p "{\\"metadata\\":{\\"annotations\\":{\\"ref\\":\\"${IMAGE_TAG}\\"}}}"							
                         '''
 					}
 					startOpenShiftBuild('prd', '${IMAGE_TAG}')

--- a/openshift/Jenkinsfile
+++ b/openshift/Jenkinsfile
@@ -104,10 +104,10 @@ pipeline {
 					script {
 						sh '''#!/bin/bash
 							oc -n $OC_PROJECT patch "bc/${APP_NAME}-int" -p "{\\"spec\\":{\\"source\\":{\\"git\\":{\\"ref\\":\\"${GIT_SHORT_COMMIT}\\"}}}}"
-							oc -n $OC_PROJECT patch "bc/${APP_NAME}-int" -p "{\\"metadata\\":{\\"annotations\\":{\\"ref\\":\\"PR-${GITHUB_PR_NUMBER}\\"}}}"
+							oc -n $OC_PROJECT patch "bc/${APP_NAME}-int" -p "{\\"metadata\\":{\\"annotations\\":{\\"ref\\":\\"${BRANCH_NAME}\\"}}}"
                         '''
 					}
-					startOpenShiftBuild('int', '$APP_NAME:PR-${GITHUB_PR_NUMBER}')
+					startOpenShiftBuild('int', '$APP_NAME:${BRANCH_NAME}')
 				}
 			}
 			post {

--- a/openshift/Jenkinsfile
+++ b/openshift/Jenkinsfile
@@ -101,7 +101,13 @@ pipeline {
 			}
 			steps {
 				container('oc') {
-					startOpenShiftBuild('int')
+					script {
+						sh '''#!/bin/bash
+							oc -n $OC_PROJECT patch "bc/${APP_NAME}-int" -p "{\\"spec\\":{\\"source\\":{\\"git\\":{\\"ref\\":\\"${GIT_SHORT_COMMIT}\\"}}}}"
+							oc -n $OC_PROJECT patch "bc/${APP_NAME}-int" -p "{\\"metadata\\":{\\"annotations\\":{\\"ref\\":{\\"PR-${GITHUB_PR_NUMBER}\\"}}}"
+                        '''
+					}
+					startOpenShiftBuild('int', '$APP_NAME:PR-${GITHUB_PR_NUMBER}')
 				}
 			}
 			post {
@@ -119,7 +125,7 @@ pipeline {
 			}
 			steps {
 				container('oc') {
-					startOpenShiftBuild('tst')
+					startOpenShiftBuild('tst', '$APP_NAME:$GIT_SHORT_COMMIT')
 				}
 			}
 			post {
@@ -193,7 +199,7 @@ pipeline {
 			}
 			steps {
 				container('oc') {
-					startOpenShiftBuild('qas')
+					startOpenShiftBuild('qas', '$APP_NAME:$GIT_SHORT_COMMIT')
 				}
 			}
 			post {
@@ -208,7 +214,13 @@ pipeline {
 			}
 			steps {
 				container('oc') {
-					startOpenShiftBuild('prd')
+					script {
+						sh '''#!/bin/bash
+							oc -n $OC_PROJECT patch "bc/${APP_NAME}-prd" -p "{\\"spec\\":{\\"source\\":{\\"git\\":{\\"ref\\":\\"${IMAGE_TAG}\\"}}}}"
+							oc -n $OC_PROJECT patch "bc/${APP_NAME}-prd" -p "{\\"metadata\\":{\\"annotations\\":{\\"ref\\":{\\"${IMAGE_TAG}\\"}}}"							
+                        '''
+					}
+					startOpenShiftBuild('prd', '${IMAGE_TAG}')
 				}
 			}
 			post {
@@ -273,7 +285,7 @@ String getAllCommitsBetweenTags(String from, String to) {
 	return commit_messages
 }
 
-void startOpenShiftBuild(String environment) {
+void startOpenShiftBuild(String environment, String dockerTag) {
 		sh """#!/bin/bash
 		oc project $OC_PROJECT
 		oc start-build --follow=true --wait=true $APP_NAME-${environment}
@@ -281,7 +293,7 @@ void startOpenShiftBuild(String environment) {
 		oc rollout status deployment/$APP_NAME-${environment} --watch=true --timeout=10m
 
 		# Tag with the revision for rollback purposes
-		oc tag $APP_NAME:${environment} $APP_NAME:$GIT_SHORT_COMMIT-${environment}
+		oc tag $APP_NAME:${environment} $APP_NAME:${dockerTag}
 	"""
 }
 

--- a/openshift/Jenkinsfile
+++ b/openshift/Jenkinsfile
@@ -108,7 +108,7 @@ pipeline {
 							oc -n $OC_PROJECT patch "bc/${APP_NAME}-int" -p "{\\"metadata\\":{\\"annotations\\":{\\"shortcommit\\":\\"${GIT_SHORT_COMMIT}\\"}}}"
                         '''
 					}
-					startOpenShiftBuild('int', '$APP_NAME:${BRANCH_NAME}')
+					startOpenShiftBuild('int', '${BRANCH_NAME}')
 				}
 			}
 			post {
@@ -126,7 +126,7 @@ pipeline {
 			}
 			steps {
 				container('oc') {
-					startOpenShiftBuild('tst', '$APP_NAME:$GIT_SHORT_COMMIT')
+					startOpenShiftBuild('tst', '$GIT_SHORT_COMMIT')
 				}
 			}
 			post {
@@ -200,7 +200,7 @@ pipeline {
 			}
 			steps {
 				container('oc') {
-					startOpenShiftBuild('qas', '$APP_NAME:$GIT_SHORT_COMMIT')
+					startOpenShiftBuild('qas', '$GIT_SHORT_COMMIT')
 				}
 			}
 			post {

--- a/openshift/Jenkinsfile
+++ b/openshift/Jenkinsfile
@@ -74,44 +74,23 @@ pipeline {
 				}
 			}
 		}
-		stage('Build code') {
-			when {
-				anyOf {
-					buildingTag()
-					changeRequest target: 'main'
-					changeRequest target: 'master'
-					changeRequest target: 'develop'
-					changeRequest target: 'development'
-				}
-			}
+		stage('Import images') {
+
 			steps {
 				container('oc') {
-					script {
-						if(buildingTag()){
-							env.ENVIRON = "prd"
-						}
-						else if(anyOf {changeRequest target: 'main' changeRequest target: 'master' changeRequest target: 'develop' changeRequest target: 'development'}){
-							env.ENVIRON = "int"
-						}
-					}
 					script {
 						sh '''#!/bin/bash
                             oc project $OC_PROJECT
                             oc import-image $BASE_IMG --confirm
                             oc set image-lookup $BASE_IMG_NAME
                             sleep 3
-                            oc annotate --overwrite "buildconfig/${APP_NAME}-${ENVIRON}"  ref=$BRANCH_NAME shortcommit=$GIT_SHORT_COMMIT
-							echo "enviroment: ${ENVIRON}"
-							export IST=${APP_NAME}:${GIT_SHORT_COMMIT}
-							echo setting ImageStreamTag ${IST} git ref
-							oc -n $OC_PROJECT patch "bc/${APP_NAME}-${ENVIRON}" -p "{\\"spec\\":{\\"output\\":{\\"to\\":{\\"name\\":\\"${IST}\\"}}}}"
-                            oc start-build --follow=true --wait=true --from-dir=. ${APP_NAME}-${ENVIRON}
                         '''
 					}
 				}
 			}
 		}
-		stage('Deploy INT') {
+
+		stage('Build and Deploy INT') {
 			when {
 				anyOf {
 					changeRequest target: 'main'
@@ -122,7 +101,7 @@ pipeline {
 			}
 			steps {
 				container('oc') {
-					tagNewImage('int')
+					startOpenShiftBuild('int')
 				}
 			}
 			post {
@@ -140,13 +119,7 @@ pipeline {
 			}
 			steps {
 				container('oc') {
-					// tagNewImage('tst')
-					script {
-						sh """#!/bin/bash
-                            oc project $OC_PROJECT
-                            oc start-build --follow=true --wait=true client-tst
-                        """
-					}
+					startOpenShiftBuild('tst')
 				}
 			}
 			post {
@@ -220,12 +193,7 @@ pipeline {
 			}
 			steps {
 				container('oc') {
-					script {
-						sh """#!/bin/bash
-                            oc project $OC_PROJECT
-                            oc start-build --follow=true --wait=true client-qas
-                        """
-					}
+					startOpenShiftBuild('qas')
 				}
 			}
 			post {
@@ -234,13 +202,13 @@ pipeline {
 				}
 			}
 		}
-		stage('Deploy PRD') {
+		stage('Build and Deploy PRD') {
 			when {
 				buildingTag()
 			}
 			steps {
 				container('oc') {
-					tagNewImage('prd')
+					startOpenShiftBuild('prd')
 				}
 			}
 			post {
@@ -305,13 +273,15 @@ String getAllCommitsBetweenTags(String from, String to) {
 	return commit_messages
 }
 
-void tagNewImage(String environment) {
-	echo "Deploying to ${environment}"
-	sh """#!/bin/bash
+void startOpenShiftBuild(String environment) {
+		sh """#!/bin/bash
 		oc project $OC_PROJECT
-		oc tag $APP_NAME:$GIT_SHORT_COMMIT $APP_NAME:${environment}
+		oc start-build --follow=true --wait=true $APP_NAME-${environment}
 		# Check the status of the rollout
 		oc rollout status deployment/$APP_NAME-${environment} --watch=true --timeout=10m
+
+		# Tag with the revision for rollback purposes
+		oc tag $APP_NAME:${environment} $APP_NAME:$GIT_SHORT_COMMIT-${environment}
 	"""
 }
 


### PR DESCRIPTION
Make sure the Docker image build for INT uses the correct OpenShift build:
 - Make separate build for every environment.
 - Make build function for reuse.
 - After Docker image build, tag image with the short-ref in order to be able to use as rollback if needed.
 - Remove some non-used code.