### PR TITLE
AVO-37: fix styling for usergroup selector

### DIFF
--- a/src/styles/admin-core/_content-pages.scss
+++ b/src/styles/admin-core/_content-pages.scss
@@ -178,6 +178,22 @@ $content-page-sidebar-blok-dropdown-height: 7rem;
 			}
 		}
 	}
+
+	.right-side-content-page-nav .c-user-group-select  {
+		.c-checkbox-group{
+			border: none;
+			border-radius: 0;
+			padding: 0;
+
+			.c-checkbox {
+				border-radius: 0;
+
+				.c-checkbox__check-icon {
+					margin: 1.5rem 2.2rem;
+				}
+			}
+		}
+	}
 }
 
 .c-content-block {


### PR DESCRIPTION
WIth adding the user group selector in the [admin-core](https://github.com/viaacode/react-admin-core-module/pull/306) for AVO, we need to overwrite some of the default styling in Het Archief to avoid a weird layout in the dropdown.

<img width="514" height="663" alt="Screenshot 2025-09-19 at 13 19 04" src="https://github.com/user-attachments/assets/1556063a-ddb8-4cc8-aada-53a9597b5d0b" />

vs

<img width="514" height="663" alt="Screenshot 2025-09-19 at 13 18 56" src="https://github.com/user-attachments/assets/daad1e6c-995b-4673-b66f-298137d652f9" />
