### PR TITLE
fix(ARC-3441): only cut video during export if start/end were changed

### DIFF
--- a/src/modules/material-requests/const/index.ts
+++ b/src/modules/material-requests/const/index.ts
@@ -172,6 +172,7 @@ export const GET_BLANK_MATERIAL_REQUEST_REUSE_FORM = (): MaterialRequestReuseFor
 	representationId: undefined,
 	startTime: 0,
 	endTime: undefined,
+	durationType: undefined,
 	downloadQuality: undefined,
 	intendedUsageDescription: undefined,
 	intendedUsage: undefined,

--- a/src/modules/material-requests/types/index.ts
+++ b/src/modules/material-requests/types/index.ts
@@ -53,6 +53,7 @@ export enum MaterialRequestReuseFormKey {
 	thumbnailUrl = 'thumbnailUrl',
 	startTime = 'startTime',
 	endTime = 'endTime',
+	durationType = 'durationType',
 	downloadQuality = 'downloadQuality',
 	intendedUsageDescription = 'intendedUsageDescription',
 	intendedUsage = 'intendedUsage',
@@ -69,10 +70,16 @@ export enum MaterialRequestReuseFormKey {
 	copyrightDisplay = 'copyrightDisplay',
 }
 
+export enum MaterialRequestDurationType {
+	FULL = 'FULL',
+	PARTIAL = 'PARTIAL',
+}
+
 export interface MaterialRequestReuseForm {
 	representationId: string | undefined;
 	startTime: number | undefined;
 	endTime: number | undefined;
+	durationType: MaterialRequestDurationType | undefined;
 	downloadQuality: MaterialRequestDownloadQuality | undefined;
 	intendedUsageDescription: string | undefined;
 	intendedUsage: MaterialRequestIntendedUsage | undefined;

--- a/src/modules/visitor-space/components/MaterialRequestForReuseBlade/MaterialRequestForReuseBlade.const.ts
+++ b/src/modules/visitor-space/components/MaterialRequestForReuseBlade/MaterialRequestForReuseBlade.const.ts
@@ -52,6 +52,8 @@ export const MATERIAL_REQUEST_REUSE_FORM_VALIDATION_SCHEMA =
 					return number().optional();
 				}
 			),
+			// Optional, since this is a computed field that is set after the validation of the form
+			[MaterialRequestReuseFormKey.durationType]: string().optional(),
 			[MaterialRequestReuseFormKey.downloadQuality]: mixed<MaterialRequestDownloadQuality>()
 				.oneOf(Object.values(MaterialRequestDownloadQuality))
 				.required(

--- a/src/modules/visitor-space/components/MaterialRequestForReuseBlade/MaterialRequestForReuseBlade.tsx
+++ b/src/modules/visitor-space/components/MaterialRequestForReuseBlade/MaterialRequestForReuseBlade.tsx
@@ -10,6 +10,7 @@ import {
 	MaterialRequestDistributionDigitalOnline,
 	MaterialRequestDistributionType,
 	MaterialRequestDownloadQuality,
+	MaterialRequestDurationType,
 	MaterialRequestEditing,
 	MaterialRequestGeographicalUsage,
 	MaterialRequestIntendedUsage,
@@ -228,13 +229,26 @@ export const MaterialRequestForReuseBlade: FC<MaterialRequestForReuseBladeProps>
 				return;
 			}
 
+			// Omit start time and end time if they are equal to 0 and media duration respectively
+			// So the backend can know when yo export the whole video and when to export only a partial
+			const formValuesToSend = {
+				...formValues,
+			};
+			if (formValues.startTime === 0 && formValues.endTime === mediaDuration) {
+				formValuesToSend[MaterialRequestReuseFormKey.durationType] =
+					MaterialRequestDurationType.FULL;
+			} else {
+				formValuesToSend[MaterialRequestReuseFormKey.durationType] =
+					MaterialRequestDurationType.PARTIAL;
+			}
+
 			const response = await MaterialRequestsService.create({
 				objectId: materialRequest.objectId,
 				objectRepresentationId: materialRequest.objectRepresentationId,
 				type: MaterialRequestType.REUSE,
 				reason: '',
 				requesterCapacity: MaterialRequestRequesterCapacity.OTHER,
-				reuseForm: formValues,
+				reuseForm: formValuesToSend,
 			});
 			if (response === undefined) {
 				onFailedRequest();


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-3441

proxy PR: https://github.com/viaacode/hetarchief-proxy/pull/612

now when the user doesn't change the start and end times when requesting material, an extra property is set for the form:
durationType: FULL
if they do change them, we set 
durationType: PARTIAL

We need these values to export the full video or a partial video when the material request is approved later.
and since we don't have a reliable way to get the duration of the video on the server, we need to store this extra variable in the db

<img width="1710" height="1273" alt="image" src="https://github.com/user-attachments/assets/f9aa4075-882f-4bc4-985e-69ee74be3111" />

<img width="2550" height="1393" alt="image" src="https://github.com/user-attachments/assets/3c38fe31-0a6f-47ef-8e8c-2517bf9db966" />

<img width="2550" height="1393" alt="image" src="https://github.com/user-attachments/assets/a1f021d7-b589-4a1d-828b-4af7f14a7646" />
