### PR TITLE
ARC-3505: add possibility to use custom component in the braft editor

### DIFF
--- a/src/modules/account/components/MaterialRequestDetailBlade/MaterialRequestConversation.tsx
+++ b/src/modules/account/components/MaterialRequestDetailBlade/MaterialRequestConversation.tsx
@@ -252,7 +252,25 @@ export const MaterialRequestConversation: FC<MaterialRequestConversationProps> =
 						placeholder={tText(
 							'modules/account/components/material-request-detail-blade/material-request-detail-blade___typ-je-bericht'
 						)}
-						controls={['bold', 'italic', 'underline', 'list-ul', 'list-ol', 'link']}
+						controls={[
+							'bold',
+							'italic',
+							'underline',
+							'list-ul',
+							'list-ol',
+							'link',
+							{
+								type: 'customButton',
+								component: (
+									// TODO: replace this with an upload component and its validation logic
+									<Button
+										variants={['sm', 'text']}
+										onClick={() => console.log('custom clicked')}
+										icon={<Icon name={IconNamesLight.File} />}
+									/>
+								),
+							},
+						]}
 						key={editorKey}
 					/>
 					<Button


### PR DESCRIPTION
Tijdelijk voorbeeld van een custom component in de rich text editor:

<img width="1717" height="961" alt="Screenshot 2026-04-13 at 14 18 17" src="https://github.com/user-attachments/assets/9aa90b0d-fa9b-4c5b-aaf0-b150bf9757c0" />
