### PR TITLE
fix(ARC-3503): refetch material request when download becomes available

### DIFF
--- a/src/modules/account/components/MaterialRequestDetailBlade/MaterialRequestConversation.tsx
+++ b/src/modules/account/components/MaterialRequestDetailBlade/MaterialRequestConversation.tsx
@@ -3,7 +3,12 @@ import { useSendMaterialRequestMessage } from '@account/components/MaterialReque
 import { MaterialRequestConversationMessage } from '@account/components/MaterialRequestDetailBlade/MaterialRequestConversationMessage';
 import { isMaterialRequestClosed } from '@account/utils/is-material-request-closed';
 import { selectCommonUser } from '@auth/store/user';
-import { type MaterialRequest, MaterialRequestStatus } from '@material-requests/types';
+import {
+	type MaterialRequest,
+	MaterialRequestDownloadStatus,
+	MaterialRequestEventType,
+	MaterialRequestStatus,
+} from '@material-requests/types';
 import {
 	Button,
 	keysEnter,
@@ -15,6 +20,7 @@ import { IconNamesLight } from '@shared/components/Icon/Icon.enums';
 import { Loading } from '@shared/components/Loading';
 import { tHtml, tText } from '@shared/helpers/translate';
 import { toastService } from '@shared/services/toast-service';
+import type { QueryObserverResult } from '@tanstack/react-query';
 import clsx from 'clsx';
 import { noop } from 'lodash-es';
 import React, {
@@ -35,12 +41,14 @@ const MATERIAL_REQUEST_CONVERSATION_PAGE_SIZE = 20;
 
 interface MaterialRequestConversationProps {
 	materialRequest: MaterialRequest;
+	refetchMaterialRequest: () => Promise<QueryObserverResult<MaterialRequest | null, Error>>;
 	handleDownload: () => void;
 	onMessagesLoaded: () => void;
 }
 
 export const MaterialRequestConversation: FC<MaterialRequestConversationProps> = ({
 	materialRequest,
+	refetchMaterialRequest,
 	handleDownload,
 	onMessagesLoaded,
 }) => {
@@ -149,14 +157,31 @@ export const MaterialRequestConversation: FC<MaterialRequestConversationProps> =
 		}
 	}, [isFetchingMessages, hasNotified, onMessagesLoaded]);
 
-	// Capture scrollHeight before every render so useLayoutEffect can correct after any page append
+	/**
+	 * Refetches the material request when a download event doesn't match the download status of the material request
+	 */
+	useEffect(() => {
+		const hasDownloadAvailableMessage: boolean = !!messages?.pages?.[0]?.items?.find(
+			(message) => message.messageType === MaterialRequestEventType.DOWNLOAD_AVAILABLE
+		);
+		const materialRequestHasNoDownload =
+			!materialRequest?.downloadStatus ||
+			[MaterialRequestDownloadStatus.NEW, MaterialRequestDownloadStatus.PENDING].includes(
+				materialRequest?.downloadStatus
+			);
+		if (hasDownloadAvailableMessage && materialRequestHasNoDownload) {
+			refetchMaterialRequest().then(noop);
+		}
+	}, [messages, materialRequest?.downloadStatus, refetchMaterialRequest]);
+
+	// Capture scrollHeight before every render so useLayoutEffect can correct after every page that is appended to the dom
 	const pageCount = messages?.pages?.length ?? 0;
 	if (scrollableRef.current && hasScrolledToBottom) {
 		previousScrollHeightRef.current = scrollableRef.current.scrollHeight;
 	}
 
 	/**
-	 * Preserve scroll position after older messages are prepended.
+	 * Preserve scroll-position after older messages are prepended.
 	 * Runs synchronously after DOM mutation but before paint.
 	 */
 

--- a/src/modules/account/components/MaterialRequestDetailBlade/MaterialRequestDetailBlade.tsx
+++ b/src/modules/account/components/MaterialRequestDetailBlade/MaterialRequestDetailBlade.tsx
@@ -46,6 +46,7 @@ import { useWindowSizeContext } from '@shared/hooks/use-window-size-context';
 import { toastService } from '@shared/services/toast-service';
 import { asDate, formatLongDate } from '@shared/utils/dates';
 import { isMobileSize } from '@shared/utils/is-mobile';
+import type { QueryObserverResult } from '@tanstack/react-query';
 import { MaterialCard } from '@visitor-space/components/MaterialCard';
 import { useIsComplexReuseFlow } from '@visitor-space/hooks/is-complex-reuse-flow';
 import clsx from 'clsx';
@@ -64,6 +65,7 @@ interface MaterialRequestDetailBladeProps {
 	onClose: (statusChanged: boolean) => void;
 	allowRequestCancellation: boolean;
 	currentMaterialRequestDetail: MaterialRequest | undefined;
+	refetchMaterialRequest: () => Promise<QueryObserverResult<MaterialRequest | null, Error>>;
 	afterStatusChanged: () => void;
 }
 
@@ -71,6 +73,7 @@ export const MaterialRequestDetailBlade: FC<MaterialRequestDetailBladeProps> = (
 	onClose,
 	allowRequestCancellation,
 	currentMaterialRequestDetail,
+	refetchMaterialRequest,
 	afterStatusChanged,
 }) => {
 	const locale = useLocale();
@@ -229,6 +232,7 @@ export const MaterialRequestDetailBlade: FC<MaterialRequestDetailBladeProps> = (
 				return (
 					<MaterialRequestConversation
 						materialRequest={currentMaterialRequestDetail}
+						refetchMaterialRequest={refetchMaterialRequest}
 						handleDownload={onHandleDownload}
 						onMessagesLoaded={() => refetchUnreadCount().then(noop)}
 					/>

--- a/src/modules/account/views/AccountMyMaterialRequests.tsx
+++ b/src/modules/account/views/AccountMyMaterialRequests.tsx
@@ -275,6 +275,7 @@ export const AccountMyMaterialRequests: FC<DefaultSeoInfo> = ({ url, canonicalUr
 				currentMaterialRequestDetail={
 					currentMaterialRequestId ? resolvedMaterialRequest : undefined
 				}
+				refetchMaterialRequest={refetchCurrentMaterialRequestDetail}
 				afterStatusChanged={onMaterialRequestStatusChange}
 			/>
 		);

--- a/src/modules/admin/views/AdminMaterialRequests.tsx
+++ b/src/modules/admin/views/AdminMaterialRequests.tsx
@@ -300,6 +300,7 @@ export const AdminMaterialRequests: FC<DefaultSeoInfo> = ({ url, canonicalUrl })
 				currentMaterialRequestDetail={
 					currentMaterialRequestId ? resolvedMaterialRequest : undefined
 				}
+				refetchMaterialRequest={refetchCurrentMaterialRequestDetail}
 				afterStatusChanged={onMaterialRequestStatusChange}
 			/>
 		);

--- a/src/modules/cp/views/CpAdminMaterialRequests.tsx
+++ b/src/modules/cp/views/CpAdminMaterialRequests.tsx
@@ -260,6 +260,7 @@ export const CpAdminMaterialRequests: FC<DefaultSeoInfo> = ({ url, canonicalUrl 
 				currentMaterialRequestDetail={
 					currentMaterialRequestId ? resolvedMaterialRequest : undefined
 				}
+				refetchMaterialRequest={refetchCurrentMaterialRequestDetail}
 				afterStatusChanged={onMaterialRequestStatusChange}
 			/>
 		);


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-3503

before: materialRequest.downloadStatus can get out of sync with events loaded in the conversation:
<img width="1440" height="1393" alt="image" src="https://github.com/user-attachments/assets/59ae4f65-b9f9-40ef-85ba-ef8c082b98d2" />


after:
TODO test this PR
