### PR TITLE
Feature/arc 3266 table status aria label

### DIFF
--- a/src/modules/account/components/MaterialRequestStatusPill/MaterialRequestStatusPill.tsx
+++ b/src/modules/account/components/MaterialRequestStatusPill/MaterialRequestStatusPill.tsx
@@ -46,6 +46,7 @@ const MaterialRequestStatusPill: FC<MaterialRequestStatusPillProps> = ({
 			<Pill
 				icon={determineIcon()}
 				label={label}
+				ariaLabel={label}
 				className={clsx(
 					styles['c-material-request-status-pill__pill'],
 					styles[`c-material-request-status-pill__pill--${status.toLowerCase()}`]

--- a/src/modules/shared/components/Pill/Pill.tsx
+++ b/src/modules/shared/components/Pill/Pill.tsx
@@ -6,7 +6,13 @@ import type { FC, ReactElement } from 'react';
 import styles from './Pill.module.scss';
 import type { PillProps } from './Pill.types';
 
-const Pill: FC<PillProps> = ({ className, icon, label, isExpanded }: PillProps): ReactElement => {
+const Pill: FC<PillProps> = ({
+	className,
+	icon,
+	label,
+	isExpanded,
+	ariaLabel,
+}: PillProps): ReactElement => {
 	const rootCls = clsx(className, styles['c-pill'], {
 		[styles['c-pill--expanded']]: isExpanded,
 	});
@@ -14,7 +20,7 @@ const Pill: FC<PillProps> = ({ className, icon, label, isExpanded }: PillProps):
 	const renderTooltipPill = (): ReactElement => (
 		<Tooltip position="right">
 			<TooltipTrigger>
-				<span className={rootCls}>
+				<span className={rootCls} role="img" aria-label={ariaLabel}>
 					<Icon name={icon} aria-hidden />
 				</span>
 			</TooltipTrigger>

--- a/src/modules/shared/components/Pill/Pill.types.ts
+++ b/src/modules/shared/components/Pill/Pill.types.ts
@@ -1,11 +1,11 @@
-import type { ReactNode } from 'react';
-
 import type { IconName } from '@shared/components/Icon';
 import type { DefaultComponentProps } from '@shared/types';
+import type { ReactNode } from 'react';
 
 export interface PillProps extends DefaultComponentProps {
 	children?: ReactNode;
 	icon: IconName;
 	label: string;
 	isExpanded?: boolean;
+	ariaLabel?: string;
 }


### PR DESCRIPTION
role="img" op de pill als workaround want pre commit hooks houdt dat tegen. Die laat geen aria-label toe op non-interactive elementen (zoals een div of een span)

