### PR TITLE
feat(archived): show archived indicator for material requests

### DIFF
--- a/src/modules/account/components/MaterialRequestStatusPill/MaterialRequestStatusPill.module.scss
+++ b/src/modules/account/components/MaterialRequestStatusPill/MaterialRequestStatusPill.module.scss
@@ -1,41 +1,48 @@
-@use "src/styles/abstracts" as *;
+@use "src/styles/abstracts" as abstracts;
 
 .c-material-request-status-pill {
-	display: flex;
+	display: inline-flex;
 	flex-direction: row;
 	align-items: center;
 	min-width: 0;
+	margin-bottom: abstracts.$spacer-xxs;
+	margin-right: abstracts.$spacer-xxs;
 
 	&__pill{
 		height: 3rem;
 		width: 4rem;
-		font-size: $font-size-2xm;
+		font-size: abstracts.$font-size-2xm;
 
 		&--new, &--cancelled {
-			background-color: $grey;
-			color: $white;
+			background-color: abstracts.$grey;
+			color: abstracts.$white;
 		}
 
 		&--pending {
-			background-color: $mustard;
-			color: $black;
+			background-color: abstracts.$mustard;
+			color: abstracts.$black;
 		}
 
 		&--approved {
-			background-color: $teal-dark;
-			color: $white;
+			background-color: abstracts.$teal-dark;
+			color: abstracts.$white;
 		}
 
 		&--denied {
-			background-color: $cherry;
-			color: $white;
+			background-color: abstracts.$cherry;
+			color: abstracts.$white;
+		}
+
+		&--archived {
+			background-color: abstracts.$grey;
+			color: abstracts.$white;
 		}
 	}
 
 	&__label {
-		color: $neutral;
-		margin-left: $spacer-xs;
+		color: abstracts.$neutral;
+		margin-left: abstracts.$spacer-xs;
 
-		@include text-ellipsis;
+		@include abstracts.text-ellipsis;
 	}
 }

--- a/src/modules/account/components/MaterialRequestStatusPill/MaterialRequestStatusPill.tsx
+++ b/src/modules/account/components/MaterialRequestStatusPill/MaterialRequestStatusPill.tsx
@@ -8,7 +8,7 @@ import type { FC } from 'react';
 import styles from './MaterialRequestStatusPill.module.scss';
 
 interface MaterialRequestStatusPillProps {
-	status: MaterialRequestStatus;
+	status: MaterialRequestStatus | 'ARCHIVED';
 	showLabel?: boolean;
 }
 
@@ -34,6 +34,8 @@ const MaterialRequestStatusPill: FC<MaterialRequestStatusPillProps> = ({
 				return IconNamesLight.Forbidden;
 			case MaterialRequestStatus.CANCELLED:
 				return IconNamesLight.Trash;
+			case 'ARCHIVED':
+				return IconNamesLight.PaperClip;
 
 			default:
 				// This should not happen

--- a/src/modules/account/const/my-material-requests.const.tsx
+++ b/src/modules/account/const/my-material-requests.const.tsx
@@ -166,7 +166,10 @@ const getStatusColumn = (disableSort: boolean): Column<MaterialRequest> =>
 		accessor: MaterialRequestKeys.status,
 		disableSortBy: disableSort,
 		Cell: ({ row: { original } }: MaterialRequestRow) => (
-			<MaterialRequestStatusPill status={original.status} />
+			<>
+				<MaterialRequestStatusPill status={original.status} />
+				<MaterialRequestStatusPill status={'ARCHIVED' as const} />
+			</>
 		),
 	}) as Column<MaterialRequest>;
 

--- a/src/modules/material-requests/const/index.ts
+++ b/src/modules/material-requests/const/index.ts
@@ -33,7 +33,7 @@ export const GET_MATERIAL_REQUEST_TRANSLATIONS_BY_TYPE = (): Record<
 });
 
 export const GET_MATERIAL_REQUEST_TRANSLATIONS_BY_STATUS = (): Record<
-	MaterialRequestStatus,
+	MaterialRequestStatus | 'ARCHIVED',
 	string
 > => ({
 	[MaterialRequestStatus.NEW]: tText('modules/material-requests/const/index___status-new'),
@@ -46,6 +46,7 @@ export const GET_MATERIAL_REQUEST_TRANSLATIONS_BY_STATUS = (): Record<
 		'modules/material-requests/const/index___status-cancelled'
 	),
 	[MaterialRequestStatus.NONE]: tText('modules/material-requests/const/index___status-none'),
+	ARCHIVED: tText('Gearchiveerd'),
 });
 
 export const GET_MATERIAL_REQUEST_TRANSLATIONS_BY_DOWNLOAD_QUALITY = (): Record<
@@ -214,6 +215,6 @@ export const MATERIAL_REQUESTS_COLUMN_WIDTH_LOOKUP: Record<MaterialRequestKeys, 
 	[MaterialRequestKeys.type]: '13rem',
 	[MaterialRequestKeys.requestedAt]: '15rem',
 	[MaterialRequestKeys.requestGroupName]: '25rem',
-	[MaterialRequestKeys.status]: '9rem',
+	[MaterialRequestKeys.status]: '11rem',
 	[MaterialRequestKeys.downloadStatus]: '10rem',
 } as Record<MaterialRequestKeys, string>;


### PR DESCRIPTION
it seems a bit strange to not show any indicator for material requests that havee been archived
since checking the filter or unchecking it, just shows some more or less material requests, but you don't see which is which

I suspect they will want to show an indicator
here is the PR for that. But let's not merge it yet
<img width="2545" height="1393" alt="image" src="https://github.com/user-attachments/assets/dac57046-0cf0-4c0a-82a7-0543a50ff85f" />
