### PR TITLE
fix: truncate long file names

### DIFF
--- a/src/modules/account/components/MaterialRequestDetailBlade/MaterialRequestConversationInput.tsx
+++ b/src/modules/account/components/MaterialRequestDetailBlade/MaterialRequestConversationInput.tsx
@@ -26,24 +26,6 @@ import { v4 as uuid } from 'uuid';
 import styles from './MaterialRequestConversation.module.scss';
 import { MessageFileUpload } from './MessageFileUpload';
 
-const truncateFilename = (filename: string, maxLength: number): string => {
-	if (filename.length <= maxLength) {
-		return filename;
-	}
-
-	const lastDotIndex = filename.lastIndexOf('.');
-	const extension = lastDotIndex > 0 ? filename.substring(lastDotIndex) : '';
-	const nameWithoutExtension = lastDotIndex > 0 ? filename.substring(0, lastDotIndex) : filename;
-
-	const maxNameLength = maxLength - extension.length - 3;
-
-	if (maxNameLength <= 0) {
-		return `${filename.substring(0, maxLength - 3)}...`;
-	}
-
-	return `${nameWithoutExtension.substring(0, maxNameLength)}...${extension}`;
-};
-
 type MaterialRequestConversationInputProps = {
 	materialRequest: MaterialRequest;
 	onAttachmentsChanged: (fileListHeight: number) => void;
@@ -167,7 +149,7 @@ export const MaterialRequestConversationInput: FC<MaterialRequestConversationInp
 							label: (
 								<>
 									<Icon name={IconNamesLight.File} />
-									<span>{truncateFilename(file.name, 30)}</span>
+									<span>{file.name}</span>
 									<span> ({Math.round((file.size / 1024 / 1024) * 100) / 100} MB)</span>
 								</>
 							),

--- a/src/modules/account/components/MaterialRequestDetailBlade/MaterialRequestConversationInput.tsx
+++ b/src/modules/account/components/MaterialRequestDetailBlade/MaterialRequestConversationInput.tsx
@@ -26,6 +26,24 @@ import { v4 as uuid } from 'uuid';
 import styles from './MaterialRequestConversation.module.scss';
 import { MessageFileUpload } from './MessageFileUpload';
 
+const truncateFilename = (filename: string, maxLength: number): string => {
+	if (filename.length <= maxLength) {
+		return filename;
+	}
+
+	const lastDotIndex = filename.lastIndexOf('.');
+	const extension = lastDotIndex > 0 ? filename.substring(lastDotIndex) : '';
+	const nameWithoutExtension = lastDotIndex > 0 ? filename.substring(0, lastDotIndex) : filename;
+
+	const maxNameLength = maxLength - extension.length - 3;
+
+	if (maxNameLength <= 0) {
+		return `${filename.substring(0, maxLength - 3)}...`;
+	}
+
+	return `${nameWithoutExtension.substring(0, maxNameLength)}...${extension}`;
+};
+
 type MaterialRequestConversationInputProps = {
 	materialRequest: MaterialRequest;
 	onAttachmentsChanged: (fileListHeight: number) => void;
@@ -149,7 +167,7 @@ export const MaterialRequestConversationInput: FC<MaterialRequestConversationInp
 							label: (
 								<>
 									<Icon name={IconNamesLight.File} />
-									<span>{file.name}</span>
+									<span>{truncateFilename(file.name, 30)}</span>
 									<span> ({Math.round((file.size / 1024 / 1024) * 100) / 100} MB)</span>
 								</>
 							),

--- a/src/styles/components/_tag.scss
+++ b/src/styles/components/_tag.scss
@@ -36,7 +36,7 @@
  */
 
 .c-tag--closable {
-	height: 3.6rem;
+	height: auto;
 	border-radius: 1.8em;
 	padding-right: 0;
 }


### PR DESCRIPTION
Te lange file names worden ge-truncate.

File extension en size blijven zichtbaar

<img width="737" height="252" alt="image" src="https://github.com/user-attachments/assets/b9d22520-b3ea-4a9c-9059-8183316d3456" />
