### PR TITLE
fix: force Flowplayer full screen icon alignment on mobile

### DIFF
--- a/src/styles/components/_flowplayer.scss
+++ b/src/styles/components/_flowplayer.scss
@@ -48,4 +48,18 @@
 	.c-video-player-inner {
 		background-color: $silver !important;
 	}
+
+	// Using padding 1em because rem-based $spacer-sm causes misalignment (Flowplayer uses em-based layout)
+	.fp-header {
+		align-items: center !important;
+		padding: 1em !important;
+
+		.fp-right {
+			display: flex !important;
+			align-items: center !important;
+			justify-content: flex-end !important;
+			flex: 1 !important;
+			text-align: right !important;
+		}
+	}
 }

--- a/src/styles/components/_flowplayer.scss
+++ b/src/styles/components/_flowplayer.scss
@@ -49,17 +49,17 @@
 		background-color: $silver !important;
 	}
 
-	// Using padding 1em because rem-based $spacer-sm causes misalignment (Flowplayer uses em-based layout)
 	.fp-header {
 		align-items: center !important;
-		padding: 1em !important;
+		justify-content: space-between !important;
 
 		.fp-right {
-			display: flex !important;
-			align-items: center !important;
-			justify-content: flex-end !important;
-			flex: 1 !important;
-			text-align: right !important;
+			position: absolute !important;
+			left: 50% !important;
+			top: 50% !important;
+			transform: translate(-50%, -50%) !important;
+			text-align: center !important;
+			background: transparent !important;
 		}
 	}
 }

--- a/src/styles/components/_flowplayer.scss
+++ b/src/styles/components/_flowplayer.scss
@@ -50,16 +50,12 @@
 	}
 
 	.fp-header {
-		align-items: center !important;
-		justify-content: space-between !important;
-
 		.fp-right {
 			position: absolute !important;
 			left: 50% !important;
 			top: 50% !important;
 			transform: translate(-50%, -50%) !important;
 			text-align: center !important;
-			background: transparent !important;
 		}
 	}
 }


### PR DESCRIPTION
Heb moeten prutsen met de flowplayer classes en daarop een positie forceren want die springen soms echt in het rond. Als iemand een elegantere oplossing heeft, be my guest 😄

Maar het lijkt wel te werken zo.

Before:

https://github.com/user-attachments/assets/2da20060-61eb-4cfc-a493-fd572aeaa2ae

After:

https://github.com/user-attachments/assets/a6650630-d640-4fde-908f-e40793c606d9

