### PR TITLE
feat: warning when conditions haven't been evaluated + cta switch

### DIFF
--- a/src/modules/account/components/MaterialRequestDetailBlade/MaterialRequestConversationMessage.tsx
+++ b/src/modules/account/components/MaterialRequestDetailBlade/MaterialRequestConversationMessage.tsx
@@ -169,6 +169,12 @@ export const MaterialRequestConversationMessage: FC<MaterialRequestConversationM
 	};
 
 	const renderAdditionalConditions = () => {
+		const conditionsEvaluated = materialRequest.history?.some(
+			(event) =>
+				event.messageType === MaterialRequestEventType.ADDITIONAL_CONDITIONS_ACCEPTED ||
+				event.messageType === MaterialRequestEventType.ADDITIONAL_CONDITIONS_DENIED
+		);
+
 		return (
 			<>
 				<div className={clsx(styles['p-conversation-messages__message__body'])}>
@@ -180,7 +186,7 @@ export const MaterialRequestConversationMessage: FC<MaterialRequestConversationM
 					)}
 				</div>
 
-				{isRequester && (
+				{isRequester && !conditionsEvaluated && (
 					<Button
 						label={tText('Voorwaarden evalueren')}
 						variants={['dark']}

--- a/src/modules/account/components/MaterialRequestDetailBlade/MaterialRequestConversationMessage.tsx
+++ b/src/modules/account/components/MaterialRequestDetailBlade/MaterialRequestConversationMessage.tsx
@@ -169,7 +169,7 @@ export const MaterialRequestConversationMessage: FC<MaterialRequestConversationM
 	};
 
 	const renderAdditionalConditions = () => {
-		const conditionsEvaluated = materialRequest.history?.some(
+		const conditionsEvaluated = materialRequest.history.some(
 			(event) =>
 				event.messageType === MaterialRequestEventType.ADDITIONAL_CONDITIONS_ACCEPTED ||
 				event.messageType === MaterialRequestEventType.ADDITIONAL_CONDITIONS_DENIED

--- a/src/modules/account/components/MaterialRequestDetailBlade/MaterialRequestDetailBlade.tsx
+++ b/src/modules/account/components/MaterialRequestDetailBlade/MaterialRequestDetailBlade.tsx
@@ -285,6 +285,10 @@ export const MaterialRequestDetailBlade: FC<MaterialRequestDetailBladeProps> = (
 		}
 	};
 
+	const onHandleDenyRequest = () => {
+		setIsDetailStatusBladeOpenWithStatus(MaterialRequestStatus.DENIED);
+	};
+
 	const renderContent = () => {
 		if (!materialRequest) {
 			return null;
@@ -517,9 +521,7 @@ export const MaterialRequestDetailBlade: FC<MaterialRequestDetailBladeProps> = (
 						onApproveRequest={() =>
 							setIsDetailStatusBladeOpenWithStatus(MaterialRequestStatus.APPROVED)
 						}
-						onDeclineRequest={() =>
-							setIsDetailStatusBladeOpenWithStatus(MaterialRequestStatus.DENIED)
-						}
+						onDeclineRequest={onHandleDenyRequest}
 						onRequestAdditionalConditions={() => setIsAdditionalConditionsBladeOpen(true)}
 					/>
 				</DropdownContent>
@@ -813,9 +815,7 @@ export const MaterialRequestDetailBlade: FC<MaterialRequestDetailBladeProps> = (
 						onApproveRequest={() =>
 							setIsDetailStatusBladeOpenWithStatus(MaterialRequestStatus.APPROVED)
 						}
-						onDeclineRequest={() =>
-							setIsDetailStatusBladeOpenWithStatus(MaterialRequestStatus.DENIED)
-						}
+						onDeclineRequest={onHandleDenyRequest}
 						onRequestAdditionalConditions={() => {
 							setIsAdditionalConditionsBladeOpen(true);
 						}}
@@ -833,6 +833,7 @@ export const MaterialRequestDetailBlade: FC<MaterialRequestDetailBladeProps> = (
 				currentMaterialRequestDetail={materialRequest}
 				layer={isDetailStatusBladeOpenWithStatus ? getStatusUpdateBladeLayer() : 99}
 				currentLayer={isDetailBladeOpen ? getBladeLayerIndex() : 9999}
+				hasPendingAdditionalConditions={requestHasAdditionalConditionsAsked}
 			/>
 			<MaterialRequestAdditionalConditionsBlade
 				isOpen={isAdditionalConditionsBladeOpen}
@@ -867,7 +868,7 @@ export const MaterialRequestDetailBlade: FC<MaterialRequestDetailBladeProps> = (
 			<MaterialRequestEvaluateConditionsBlade
 				isOpen={!!evaluateConditionsMessage}
 				onClose={() => setEvaluateConditionsMessage(null)}
-				message={evaluateConditionsMessage as MaterialRequestMessage}
+				message={evaluateConditionsMessage}
 				layer={evaluateConditionsMessage ? getEvaluateConditionsBladeLayer() : 99}
 				currentLayer={isDetailBladeOpen ? getBladeLayerIndex() : 9999}
 				materialRequestId={currentMaterialRequestDetail?.id}

--- a/src/modules/account/components/MaterialRequestDetailBlade/MaterialRequestDetailBlade.tsx
+++ b/src/modules/account/components/MaterialRequestDetailBlade/MaterialRequestDetailBlade.tsx
@@ -285,10 +285,6 @@ export const MaterialRequestDetailBlade: FC<MaterialRequestDetailBladeProps> = (
 		}
 	};
 
-	const onHandleDenyRequest = () => {
-		setIsDetailStatusBladeOpenWithStatus(MaterialRequestStatus.DENIED);
-	};
-
 	const renderContent = () => {
 		if (!materialRequest) {
 			return null;
@@ -521,7 +517,9 @@ export const MaterialRequestDetailBlade: FC<MaterialRequestDetailBladeProps> = (
 						onApproveRequest={() =>
 							setIsDetailStatusBladeOpenWithStatus(MaterialRequestStatus.APPROVED)
 						}
-						onDeclineRequest={onHandleDenyRequest}
+						onDeclineRequest={() =>
+							setIsDetailStatusBladeOpenWithStatus(MaterialRequestStatus.DENIED)
+						}
 						onRequestAdditionalConditions={() => setIsAdditionalConditionsBladeOpen(true)}
 					/>
 				</DropdownContent>
@@ -815,7 +813,9 @@ export const MaterialRequestDetailBlade: FC<MaterialRequestDetailBladeProps> = (
 						onApproveRequest={() =>
 							setIsDetailStatusBladeOpenWithStatus(MaterialRequestStatus.APPROVED)
 						}
-						onDeclineRequest={onHandleDenyRequest}
+						onDeclineRequest={() =>
+							setIsDetailStatusBladeOpenWithStatus(MaterialRequestStatus.DENIED)
+						}
 						onRequestAdditionalConditions={() => {
 							setIsAdditionalConditionsBladeOpen(true);
 						}}

--- a/src/modules/account/components/MaterialRequestEvaluateConditionsBlade/MaterialRequestEvaluateConditionsBlade.tsx
+++ b/src/modules/account/components/MaterialRequestEvaluateConditionsBlade/MaterialRequestEvaluateConditionsBlade.tsx
@@ -15,7 +15,7 @@ import styles from './MaterialRequestEvaluateConditionsBlade.module.scss';
 interface MaterialRequestEvaluateConditionsBladeProps {
 	isOpen: boolean;
 	onClose: () => void;
-	message: MaterialRequestMessage;
+	message: MaterialRequestMessage | null;
 	layer: number;
 	currentLayer: number;
 	materialRequestId: string | undefined;
@@ -26,7 +26,9 @@ export const MaterialRequestEvaluateConditionsBlade: FC<
 	MaterialRequestEvaluateConditionsBladeProps
 > = ({ isOpen, onClose, message, layer, currentLayer, materialRequestId, onSuccess }) => {
 	const conditionLabels = GET_MATERIAL_REQUEST_TRANSLATIONS_BY_ADDITIONAL_CONDITIONS_TYPE();
-	const conditions = (message.body as MaterialRequestMessageBodyAdditionalConditions)?.conditions;
+	const conditions = message
+		? (message.body as MaterialRequestMessageBodyAdditionalConditions)?.conditions
+		: [];
 	const [showDeclineConfirmModal, setShowDeclineConfirmModal] = useState(false);
 
 	const { mutateAsync: evaluateExtraConditions, isPending: isSubmitting } =
@@ -164,15 +166,15 @@ export const MaterialRequestEvaluateConditionsBlade: FC<
 			<ConfirmationModal
 				isOpen={showDeclineConfirmModal}
 				onClose={handleDeclineCancel}
-				onConfirm={handleDeclineConfirm}
-				onCancel={handleDeclineCancel}
+				onConfirm={handleDeclineCancel}
+				onCancel={handleDeclineConfirm}
 				text={{
 					title: tText('Aanvraag annuleren?'),
 					description: tText(
 						'Ben je zeker dat je deze aanvraag wilt annuleren? Deze actie kan niet ongedaan gemaakt worden.'
 					),
-					yes: tText('Ja, annuleer aanvraag'),
-					no: tText('Nee, keer terug'),
+					yes: tText('Nee, keer terug'),
+					no: tText('Ja, annuleer aanvraag'),
 				}}
 			/>
 		</>

--- a/src/modules/account/components/MaterialRequestStatusUpdateBlade/MaterialRequestStatusUpdateBlade.tsx
+++ b/src/modules/account/components/MaterialRequestStatusUpdateBlade/MaterialRequestStatusUpdateBlade.tsx
@@ -155,92 +155,90 @@ export const MaterialRequestStatusUpdateBlade: FC<MaterialRequestStatusUpdateBla
 	};
 
 	return (
-		<>
-			<Blade
-				id="material-request-status-update-blade"
-				className={styles['c-request-material-status-update']}
-				isOpen={isOpen}
-				layer={layer}
-				currentLayer={currentLayer}
-				onClose={() => onCloseModal(false)}
-				isManaged
-				title={
-					status === MaterialRequestStatus.APPROVED
-						? tText(
-								'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___aanvraag-goedkeuren-titel'
-							)
-						: tText(
-								'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___aanvraag-afkeuren-titel'
-							)
-				}
-				ariaLabel={tText(
-					'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___materiaal-aanvraag-goedkeuren-of-afkeuren-blade-aria-label'
-				)}
-				stickySubtitle={<MaterialRequestInformation />}
-				subtitle={
-					<MaterialCard
-						openInNewTab={true}
-						objectSchemaIdentifier={objectSchemaIdentifier}
-						title={objectName}
-						thumbnail={objectThumbnailUrl}
-						hideThumbnail={true}
-						orientation="vertical"
-						link={`/${ROUTE_PARTS_BY_LOCALE[locale].search}/${maintainerSlug}/${objectSchemaIdentifier}`}
-						type={objectDctermsFormat}
-						publishedBy={maintainerName}
-						publishedOrCreatedDate={objectPublishedOrCreatedDate}
-						icon={getIconFromObjectType(objectDctermsFormat, isObjectEssenceAccessibleToUser)}
-					/>
-				}
-				footerButtons={getFooterButtons()}
-			>
-				<div className={styles['c-request-material-status-update__content']}>
-					<dl>
-						<dt className={styles['c-request-material-status-update__content-label']}>
-							<label htmlFor="motivation-input">
-								{status === MaterialRequestStatus.APPROVED
-									? tHtml(
-											'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___aanvraag-goedkeuren-description'
-										)
-									: tHtml(
-											'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___aanvraag-afkeuren-description'
-										)}
-							</label>
-						</dt>
-						<dd className={styles['c-request-material-status-update__content-value']}>
-							<FormControl
-								label={
-									status === MaterialRequestStatus.APPROVED
-										? tText(
-												'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___motivatie-aanvraag-goedkeuren'
-											)
-										: tText(
-												'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___motivatie-aanvraag-afkeuren'
-											)
-								}
-								errors={[
-									<MaxLengthIndicator
-										maxLength={MAX_MOTIVATION_LENGTH}
-										value={motivationInputValue}
-										key={`form-error--motivation`}
-									/>,
-								]}
-							>
-								<TextArea
-									id="motivation-input"
-									className={styles['c-request-material-status-update__motivation-input']}
-									maxLength={MAX_MOTIVATION_LENGTH}
-									onChange={(e) => setMotivationInputValue(e.target.value)}
-									value={motivationInputValue}
-									ariaLabel={tText(
-										'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___motivatie-voor-het-goedkeuren-of-afkeuren-van-de-aanvraag-input-aria-label'
+		<Blade
+			id="material-request-status-update-blade"
+			className={styles['c-request-material-status-update']}
+			isOpen={isOpen}
+			layer={layer}
+			currentLayer={currentLayer}
+			onClose={() => onCloseModal(false)}
+			isManaged
+			title={
+				status === MaterialRequestStatus.APPROVED
+					? tText(
+							'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___aanvraag-goedkeuren-titel'
+						)
+					: tText(
+							'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___aanvraag-afkeuren-titel'
+						)
+			}
+			ariaLabel={tText(
+				'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___materiaal-aanvraag-goedkeuren-of-afkeuren-blade-aria-label'
+			)}
+			stickySubtitle={<MaterialRequestInformation />}
+			subtitle={
+				<MaterialCard
+					openInNewTab={true}
+					objectSchemaIdentifier={objectSchemaIdentifier}
+					title={objectName}
+					thumbnail={objectThumbnailUrl}
+					hideThumbnail={true}
+					orientation="vertical"
+					link={`/${ROUTE_PARTS_BY_LOCALE[locale].search}/${maintainerSlug}/${objectSchemaIdentifier}`}
+					type={objectDctermsFormat}
+					publishedBy={maintainerName}
+					publishedOrCreatedDate={objectPublishedOrCreatedDate}
+					icon={getIconFromObjectType(objectDctermsFormat, isObjectEssenceAccessibleToUser)}
+				/>
+			}
+			footerButtons={getFooterButtons()}
+		>
+			<div className={styles['c-request-material-status-update__content']}>
+				<dl>
+					<dt className={styles['c-request-material-status-update__content-label']}>
+						<label htmlFor="motivation-input">
+							{status === MaterialRequestStatus.APPROVED
+								? tHtml(
+										'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___aanvraag-goedkeuren-description'
+									)
+								: tHtml(
+										'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___aanvraag-afkeuren-description'
 									)}
-								/>
-							</FormControl>
-						</dd>
-					</dl>
-				</div>
-			</Blade>
+						</label>
+					</dt>
+					<dd className={styles['c-request-material-status-update__content-value']}>
+						<FormControl
+							label={
+								status === MaterialRequestStatus.APPROVED
+									? tText(
+											'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___motivatie-aanvraag-goedkeuren'
+										)
+									: tText(
+											'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___motivatie-aanvraag-afkeuren'
+										)
+							}
+							errors={[
+								<MaxLengthIndicator
+									maxLength={MAX_MOTIVATION_LENGTH}
+									value={motivationInputValue}
+									key={`form-error--motivation`}
+								/>,
+							]}
+						>
+							<TextArea
+								id="motivation-input"
+								className={styles['c-request-material-status-update__motivation-input']}
+								maxLength={MAX_MOTIVATION_LENGTH}
+								onChange={(e) => setMotivationInputValue(e.target.value)}
+								value={motivationInputValue}
+								ariaLabel={tText(
+									'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___motivatie-voor-het-goedkeuren-of-afkeuren-van-de-aanvraag-input-aria-label'
+								)}
+							/>
+						</FormControl>
+					</dd>
+				</dl>
+			</div>
 
 			<ConfirmationModal
 				isOpen={showDenyWithPendingConditionsConfirmationModal}
@@ -260,6 +258,6 @@ export const MaterialRequestStatusUpdateBlade: FC<MaterialRequestStatusUpdateBla
 					no: tText('Ja, aanvraag afkeuren en verwijder bijkomende gebruiksvoorwaarden'),
 				}}
 			/>
-		</>
+		</Blade>
 	);
 };

--- a/src/modules/account/components/MaterialRequestStatusUpdateBlade/MaterialRequestStatusUpdateBlade.tsx
+++ b/src/modules/account/components/MaterialRequestStatusUpdateBlade/MaterialRequestStatusUpdateBlade.tsx
@@ -3,6 +3,7 @@ import { type MaterialRequest, MaterialRequestStatus } from '@material-requests/
 import { FormControl, TextArea } from '@meemoo/react-components';
 import { Blade } from '@shared/components/Blade/Blade';
 import type { BladeFooterButtonProps } from '@shared/components/Blade/Blade.types';
+import { ConfirmationModal } from '@shared/components/ConfirmationModal';
 import MaxLengthIndicator from '@shared/components/FormControl/MaxLengthIndicator';
 import { MaterialRequestInformation } from '@shared/components/MaterialRequestInformation';
 import { getIconFromObjectType } from '@shared/components/MediaCard';
@@ -23,6 +24,7 @@ interface MaterialRequestStatusUpdateBladeProps {
 	currentMaterialRequestDetail: MaterialRequest | undefined;
 	layer: number;
 	currentLayer: number;
+	hasPendingAdditionalConditions?: boolean;
 }
 
 export const MaterialRequestStatusUpdateBlade: FC<MaterialRequestStatusUpdateBladeProps> = ({
@@ -32,12 +34,17 @@ export const MaterialRequestStatusUpdateBlade: FC<MaterialRequestStatusUpdateBla
 	currentMaterialRequestDetail,
 	layer,
 	currentLayer,
+	hasPendingAdditionalConditions = false,
 }) => {
 	const locale = useLocale();
 	const MAX_MOTIVATION_LENGTH = 300;
 	const { isObjectEssenceAccessibleToUser } = useIsComplexReuseFlow(currentMaterialRequestDetail);
 
 	const [motivationInputValue, setMotivationInputValue] = useState('');
+	const [
+		showDenyWithPendingConditionsConfirmationModal,
+		setShowDenyWithPendingConditionsConfirmationModal,
+	] = useState(false);
 
 	/**
 	 * Reset form when the model is opened
@@ -45,6 +52,7 @@ export const MaterialRequestStatusUpdateBlade: FC<MaterialRequestStatusUpdateBla
 	useEffect(() => {
 		if (isOpen) {
 			setMotivationInputValue('');
+			setShowDenyWithPendingConditionsConfirmationModal(false);
 		}
 	}, [isOpen]);
 
@@ -65,9 +73,19 @@ export const MaterialRequestStatusUpdateBlade: FC<MaterialRequestStatusUpdateBla
 	const onCloseModal = (statusChanged: boolean) => {
 		onClose(statusChanged);
 		setMotivationInputValue('');
+		setShowDenyWithPendingConditionsConfirmationModal(false);
 	};
 
 	const onApproveOrDeny = async () => {
+		if (status === MaterialRequestStatus.DENIED && hasPendingAdditionalConditions) {
+			setShowDenyWithPendingConditionsConfirmationModal(true);
+			return;
+		}
+
+		await performApproveOrDeny();
+	};
+
+	const performApproveOrDeny = async () => {
 		try {
 			const response =
 				status === MaterialRequestStatus.APPROVED
@@ -137,90 +155,111 @@ export const MaterialRequestStatusUpdateBlade: FC<MaterialRequestStatusUpdateBla
 	};
 
 	return (
-		<Blade
-			id="material-request-status-update-blade"
-			className={styles['c-request-material-status-update']}
-			isOpen={isOpen}
-			layer={layer}
-			currentLayer={currentLayer}
-			onClose={() => onCloseModal(false)}
-			isManaged
-			title={
-				status === MaterialRequestStatus.APPROVED
-					? tText(
-							'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___aanvraag-goedkeuren-titel'
-						)
-					: tText(
-							'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___aanvraag-afkeuren-titel'
-						)
-			}
-			ariaLabel={tText(
-				'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___materiaal-aanvraag-goedkeuren-of-afkeuren-blade-aria-label'
-			)}
-			stickySubtitle={<MaterialRequestInformation />}
-			subtitle={
-				<MaterialCard
-					openInNewTab={true}
-					objectSchemaIdentifier={objectSchemaIdentifier}
-					title={objectName}
-					thumbnail={objectThumbnailUrl}
-					hideThumbnail={true}
-					orientation="vertical"
-					link={`/${ROUTE_PARTS_BY_LOCALE[locale].search}/${maintainerSlug}/${objectSchemaIdentifier}`}
-					type={objectDctermsFormat}
-					publishedBy={maintainerName}
-					publishedOrCreatedDate={objectPublishedOrCreatedDate}
-					icon={getIconFromObjectType(objectDctermsFormat, isObjectEssenceAccessibleToUser)}
-				/>
-			}
-			footerButtons={getFooterButtons()}
-		>
-			<div className={styles['c-request-material-status-update__content']}>
-				<dl>
-					<dt className={styles['c-request-material-status-update__content-label']}>
-						<label htmlFor="motivation-input">
-							{status === MaterialRequestStatus.APPROVED
-								? tHtml(
-										'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___aanvraag-goedkeuren-description'
-									)
-								: tHtml(
-										'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___aanvraag-afkeuren-description'
-									)}
-						</label>
-					</dt>
-					<dd className={styles['c-request-material-status-update__content-value']}>
-						<FormControl
-							label={
-								status === MaterialRequestStatus.APPROVED
-									? tText(
-											'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___motivatie-aanvraag-goedkeuren'
+		<>
+			<Blade
+				id="material-request-status-update-blade"
+				className={styles['c-request-material-status-update']}
+				isOpen={isOpen}
+				layer={layer}
+				currentLayer={currentLayer}
+				onClose={() => onCloseModal(false)}
+				isManaged
+				title={
+					status === MaterialRequestStatus.APPROVED
+						? tText(
+								'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___aanvraag-goedkeuren-titel'
+							)
+						: tText(
+								'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___aanvraag-afkeuren-titel'
+							)
+				}
+				ariaLabel={tText(
+					'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___materiaal-aanvraag-goedkeuren-of-afkeuren-blade-aria-label'
+				)}
+				stickySubtitle={<MaterialRequestInformation />}
+				subtitle={
+					<MaterialCard
+						openInNewTab={true}
+						objectSchemaIdentifier={objectSchemaIdentifier}
+						title={objectName}
+						thumbnail={objectThumbnailUrl}
+						hideThumbnail={true}
+						orientation="vertical"
+						link={`/${ROUTE_PARTS_BY_LOCALE[locale].search}/${maintainerSlug}/${objectSchemaIdentifier}`}
+						type={objectDctermsFormat}
+						publishedBy={maintainerName}
+						publishedOrCreatedDate={objectPublishedOrCreatedDate}
+						icon={getIconFromObjectType(objectDctermsFormat, isObjectEssenceAccessibleToUser)}
+					/>
+				}
+				footerButtons={getFooterButtons()}
+			>
+				<div className={styles['c-request-material-status-update__content']}>
+					<dl>
+						<dt className={styles['c-request-material-status-update__content-label']}>
+							<label htmlFor="motivation-input">
+								{status === MaterialRequestStatus.APPROVED
+									? tHtml(
+											'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___aanvraag-goedkeuren-description'
 										)
-									: tText(
-											'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___motivatie-aanvraag-afkeuren'
-										)
-							}
-							errors={[
-								<MaxLengthIndicator
+									: tHtml(
+											'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___aanvraag-afkeuren-description'
+										)}
+							</label>
+						</dt>
+						<dd className={styles['c-request-material-status-update__content-value']}>
+							<FormControl
+								label={
+									status === MaterialRequestStatus.APPROVED
+										? tText(
+												'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___motivatie-aanvraag-goedkeuren'
+											)
+										: tText(
+												'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___motivatie-aanvraag-afkeuren'
+											)
+								}
+								errors={[
+									<MaxLengthIndicator
+										maxLength={MAX_MOTIVATION_LENGTH}
+										value={motivationInputValue}
+										key={`form-error--motivation`}
+									/>,
+								]}
+							>
+								<TextArea
+									id="motivation-input"
+									className={styles['c-request-material-status-update__motivation-input']}
 									maxLength={MAX_MOTIVATION_LENGTH}
+									onChange={(e) => setMotivationInputValue(e.target.value)}
 									value={motivationInputValue}
-									key={`form-error--motivation`}
-								/>,
-							]}
-						>
-							<TextArea
-								id="motivation-input"
-								className={styles['c-request-material-status-update__motivation-input']}
-								maxLength={MAX_MOTIVATION_LENGTH}
-								onChange={(e) => setMotivationInputValue(e.target.value)}
-								value={motivationInputValue}
-								ariaLabel={tText(
-									'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___motivatie-voor-het-goedkeuren-of-afkeuren-van-de-aanvraag-input-aria-label'
-								)}
-							/>
-						</FormControl>
-					</dd>
-				</dl>
-			</div>
-		</Blade>
+									ariaLabel={tText(
+										'modules/account/components/material-request-status-update-blade/material-request-status-update-blade___motivatie-voor-het-goedkeuren-of-afkeuren-van-de-aanvraag-input-aria-label'
+									)}
+								/>
+							</FormControl>
+						</dd>
+					</dl>
+				</div>
+			</Blade>
+
+			<ConfirmationModal
+				isOpen={showDenyWithPendingConditionsConfirmationModal}
+				onClose={() => setShowDenyWithPendingConditionsConfirmationModal(false)}
+				onConfirm={() => setShowDenyWithPendingConditionsConfirmationModal(false)}
+				onCancel={() => {
+					setShowDenyWithPendingConditionsConfirmationModal(false);
+					performApproveOrDeny();
+				}}
+				fullWidthButtonWrapper
+				text={{
+					title: tText('Afkeuren en bijkomende gebruiksvoorwaarden verwijderen'),
+					description: tText(
+						'Als je de aanvraag afkeurt, worden de verzonden bijkomende gebruiksvoorwaarden verwijderd. Weet je zeker dat je wil doorgaan?'
+					),
+					yes: tText('Nee, keer terug en behoud bijkomende gebruiksvoorwaarden'),
+					no: tText('Ja, aanvraag afkeuren en verwijder bijkomende gebruiksvoorwaarden'),
+				}}
+			/>
+		</>
 	);
 };


### PR DESCRIPTION
CTA nog omgedraaid in een modal, de nieuwe modal toegevoegd voor ARC-3517, nog een issue gefixt met de MaterialRequestEvaluateConditionsBlade props waardoor er een material request pagina niet wou renderen, en de "evalueer voorwaarden" button niet meer tonen in de chat als de aanvrager dat al gedaan heeft.

Op deze branch zou de volledige "bijkomende voorwaarden" flow op getest kunnen worden
