### PR TITLE
fix: chevron safari fix

### DIFF
--- a/src/modules/account/components/MaterialRequestEvaluatorOptions/MaterialRequestEvaluatorOptions.module.scss
+++ b/src/modules/account/components/MaterialRequestEvaluatorOptions/MaterialRequestEvaluatorOptions.module.scss
@@ -40,6 +40,11 @@
 			padding-left: $spacer-xs;
 			margin-left: auto;
 
+			// Safari only
+			@supports (background: -webkit-named-image(i)) {
+				padding-right: $spacer-md;
+			}
+
 			// Enable Ligatures
 			font-feature-settings: "liga";
 			font-variant-ligatures: discretionary-ligatures;


### PR DESCRIPTION
Die "-webkit-named-image" is Safari specific dus die padding gaat enkel op safari doorkomen.

Ik heb geprobeerd om die ::after weg te halen en het te doen met een icon component en flexbox maar er is zo geen chevron in de icon library, enkel een dubbele chevron of een arrow right en dat ziet er dan ook weer helemaal anders uit -->

Het is niet de properste oplossing ter wereld maar heb vanalles geprobeerd en ik krijg het anders met enkel styling niet in orde op beide browsers zonder dit te moeten doen.

Ideeën zijn welkom, maar het werkt wel 👀

**Before (safari):**
<img width="384" height="591" alt="image" src="https://github.com/user-attachments/assets/ea6f013c-4968-486c-8eec-46b6e3ec178f" />


**After (safari):**
<img width="391" height="614" alt="image" src="https://github.com/user-attachments/assets/794f08ed-8a7b-4d12-8ac1-694d80c67dd1" />


**Firefox for reference:**
<img width="380" height="618" alt="image" src="https://github.com/user-attachments/assets/cd0eada6-9202-4ed5-a7ed-867fee0b2b6f" />



