### PR TITLE
fix: mobile available video icon before vid init

### DIFF
--- a/src/modules/ie-objects/ObjectDetailPage.tsx
+++ b/src/modules/ie-objects/ObjectDetailPage.tsx
@@ -288,6 +288,7 @@ export const ObjectDetailPage: FC<DefaultSeoInfo> = ({
 		},
 		[getRepresentationByType]
 	);
+	const [isFlowPlayerMediaAvailable, setIsFlowPlayerMediaAvailable] = useState(false);
 
 	const allFilesToDisplayInCurrentPage =
 		(mediaInfo?.pages || []).flatMap((page) =>
@@ -1268,7 +1269,9 @@ export const ObjectDetailPage: FC<DefaultSeoInfo> = ({
 			case IeObjectType.VIDEO:
 			case IeObjectType.VIDEO_FRAGMENT:
 			case IeObjectType.FILM:
-				return !!getFilesByType(FLOWPLAYER_FORMATS)?.[0]?.storedAt;
+				return isMobile
+					? !!getFilesByType(FLOWPLAYER_FORMATS)?.[0]?.storedAt
+					: isFlowPlayerMediaAvailable;
 
 			case IeObjectType.NEWSPAPER: {
 				return !!getFilesByType(IMAGE_API_FORMATS)?.[0]?.storedAt;
@@ -1277,7 +1280,7 @@ export const ObjectDetailPage: FC<DefaultSeoInfo> = ({
 			default:
 				return false;
 		}
-	}, [mediaInfo?.dctermsFormat, getFilesByType]);
+	}, [mediaInfo?.dctermsFormat, isMobile, isFlowPlayerMediaAvailable, getFilesByType]);
 
 	const tabs: TabProps[] = useMemo(() => {
 		return OBJECT_DETAIL_TABS(
@@ -1443,7 +1446,7 @@ export const ObjectDetailPage: FC<DefaultSeoInfo> = ({
 				paused={isMediaPaused}
 				onPlay={handleOnPlay}
 				onPause={handleOnPause}
-				onMediaReady={noop}
+				onMediaReady={isMobile ? noop : setIsFlowPlayerMediaAvailable}
 			/>
 		);
 	};

--- a/src/modules/ie-objects/ObjectDetailPage.tsx
+++ b/src/modules/ie-objects/ObjectDetailPage.tsx
@@ -175,7 +175,6 @@ export const ObjectDetailPage: FC<DefaultSeoInfo> = ({
 	}, []);
 	const [isMediaPaused, setIsMediaPaused] = useState(true);
 	const [hasMediaPlayed, setHasMediaPlayed] = useState(false);
-	const [isFlowPlayerMediaAvailable, setIsFlowPlayerMediaAvailable] = useState(false);
 	const [similar, setSimilar] = useState<MediaObject[]>([]);
 	const [isRelatedObjectsBladeOpen, setIsRelatedObjectsBladeOpen] = useState(false);
 	const [hasNewsPaperBeenRendered, setHasNewsPaperBeenRendered] = useState(false);
@@ -1269,7 +1268,7 @@ export const ObjectDetailPage: FC<DefaultSeoInfo> = ({
 			case IeObjectType.VIDEO:
 			case IeObjectType.VIDEO_FRAGMENT:
 			case IeObjectType.FILM:
-				return isFlowPlayerMediaAvailable;
+				return !!getFilesByType(FLOWPLAYER_FORMATS)?.[0]?.storedAt;
 
 			case IeObjectType.NEWSPAPER: {
 				return !!getFilesByType(IMAGE_API_FORMATS)?.[0]?.storedAt;
@@ -1278,7 +1277,7 @@ export const ObjectDetailPage: FC<DefaultSeoInfo> = ({
 			default:
 				return false;
 		}
-	}, [mediaInfo?.dctermsFormat, isFlowPlayerMediaAvailable, getFilesByType]);
+	}, [mediaInfo?.dctermsFormat, getFilesByType]);
 
 	const tabs: TabProps[] = useMemo(() => {
 		return OBJECT_DETAIL_TABS(
@@ -1444,7 +1443,7 @@ export const ObjectDetailPage: FC<DefaultSeoInfo> = ({
 				paused={isMediaPaused}
 				onPlay={handleOnPlay}
 				onPause={handleOnPause}
-				onMediaReady={setIsFlowPlayerMediaAvailable}
+				onMediaReady={noop}
 			/>
 		);
 	};

--- a/src/modules/ie-objects/ObjectDetailPage.tsx
+++ b/src/modules/ie-objects/ObjectDetailPage.tsx
@@ -288,7 +288,10 @@ export const ObjectDetailPage: FC<DefaultSeoInfo> = ({
 		},
 		[getRepresentationByType]
 	);
-	const [isFlowPlayerMediaAvailable, setIsFlowPlayerMediaAvailable] = useState(false);
+
+	const [isFlowPlayerMediaAvailable, setIsFlowPlayerMediaAvailable] = useState<boolean | null>(
+		null
+	);
 
 	const allFilesToDisplayInCurrentPage =
 		(mediaInfo?.pages || []).flatMap((page) =>
@@ -1269,7 +1272,7 @@ export const ObjectDetailPage: FC<DefaultSeoInfo> = ({
 			case IeObjectType.VIDEO:
 			case IeObjectType.VIDEO_FRAGMENT:
 			case IeObjectType.FILM:
-				return isMobile
+				return isFlowPlayerMediaAvailable === null
 					? !!getFilesByType(FLOWPLAYER_FORMATS)?.[0]?.storedAt
 					: isFlowPlayerMediaAvailable;
 
@@ -1280,7 +1283,7 @@ export const ObjectDetailPage: FC<DefaultSeoInfo> = ({
 			default:
 				return false;
 		}
-	}, [mediaInfo?.dctermsFormat, isMobile, isFlowPlayerMediaAvailable, getFilesByType]);
+	}, [mediaInfo?.dctermsFormat, isFlowPlayerMediaAvailable, getFilesByType]);
 
 	const tabs: TabProps[] = useMemo(() => {
 		return OBJECT_DETAIL_TABS(
@@ -1446,7 +1449,7 @@ export const ObjectDetailPage: FC<DefaultSeoInfo> = ({
 				paused={isMediaPaused}
 				onPlay={handleOnPlay}
 				onPause={handleOnPause}
-				onMediaReady={isMobile ? noop : setIsFlowPlayerMediaAvailable}
+				onMediaReady={setIsFlowPlayerMediaAvailable}
 			/>
 		);
 	};

--- a/src/modules/ie-objects/ObjectDetailPage.tsx
+++ b/src/modules/ie-objects/ObjectDetailPage.tsx
@@ -1272,9 +1272,7 @@ export const ObjectDetailPage: FC<DefaultSeoInfo> = ({
 			case IeObjectType.VIDEO:
 			case IeObjectType.VIDEO_FRAGMENT:
 			case IeObjectType.FILM:
-				return isFlowPlayerMediaAvailable === null
-					? !!getFilesByType(FLOWPLAYER_FORMATS)?.[0]?.storedAt
-					: isFlowPlayerMediaAvailable;
+				return isFlowPlayerMediaAvailable ?? !!getFilesByType(FLOWPLAYER_FORMATS)?.[0]?.storedAt;
 
 			case IeObjectType.NEWSPAPER: {
 				return !!getFilesByType(IMAGE_API_FORMATS)?.[0]?.storedAt;


### PR DESCRIPTION
isFlowPlayerMediaAvailable hing af van onMediaReady en dat kwam enkel door als de videospeler initialized was (wat op mobile niet het geval was want die hangt achter een tab)


https://github.com/user-attachments/assets/f50917f3-b3fa-417d-b06b-3309d76b5e49

