### PR TITLE
fix: newspaper thumbnails

### DIFF
--- a/src/modules/shared/components/MediaCard/MediaCard.tsx
+++ b/src/modules/shared/components/MediaCard/MediaCard.tsx
@@ -316,7 +316,6 @@ const MediaCard: FC<MediaCardProps> = ({
 							? title
 							: tText('modules/shared/components/media-card/media-card___image-of-the-media-object')
 					}
-					fill={true}
 					sizes="100%"
 				/>
 				{!isNil(icon) && (


### PR DESCRIPTION
Before:
<img width="5110" height="2438" alt="image" src="https://github.com/user-attachments/assets/9333328c-e7f8-4ccb-9e75-a59099399052" />

After:
<img width="5106" height="2478" alt="image" src="https://github.com/user-attachments/assets/56a3fdc0-4745-40db-910b-a6f9d59dcfe0" />
