### PR TITLE
fix: reduce rights label font size in rechten section

### DIFF
--- a/src/modules/ie-objects/components/ObjectDetailPageMetadata/ObjectDetailPageMetadataRights.module.scss
+++ b/src/modules/ie-objects/components/ObjectDetailPageMetadata/ObjectDetailPageMetadataRights.module.scss
@@ -11,7 +11,7 @@
 		display: flex;
 		align-items: center;
 		gap: $spacer-xs;
-		font-size: $font-size-lg;
+		font-size: $font-size-base;
 		font-weight: $font-weight-bold;
 		line-height: $line-height-1xl;
 	}


### PR DESCRIPTION
## Summary

- Reduce font size of the rights label (icon + text) in the `ObjectDetailPageMetadataRights` component from `$font-size-lg` (2.4rem) to `$font-size-base` (1.6rem)

## Test plan

- [ ] Open an IE object detail page and verify the "Rechten" section label renders at the correct smaller size

🤖 Generated with [Claude Code](https://claude.com/claude-code)