### PR TITLE
fix(ARC-3595): remove Publiek domein filter, replaced by Herbruikbaarheid

### DIFF
--- a/src/modules/search/SearchPage.tsx
+++ b/src/modules/search/SearchPage.tsx
@@ -88,7 +88,6 @@ import {
 import type { AdvancedFilterFormState } from '@visitor-space/components/AdvancedFilterForm/AdvancedFilterForm.types';
 import type { ConsultableMediaFilterFormState } from '@visitor-space/components/ConsultableMediaFilterForm/ConsultableMediaFilterForm.types';
 import type { ConsultableOnlyOnLocationFilterFormState } from '@visitor-space/components/ConsultableOnlyOnLocationFilterForm/ConsultableOnlyOnLocationFilterForm.types';
-import type { ConsultablePublicDomainFilterFormState } from '@visitor-space/components/ConsultablePublicDomainFilterForm/ConsultablePublicDomainFilterForm.types';
 import type { DurationFilterFormState } from '@visitor-space/components/DurationFilterForm';
 import FilterMenu from '@visitor-space/components/FilterMenu/FilterMenu';
 import type { GenreFilterFormState } from '@visitor-space/components/GenreFilterForm';
@@ -570,14 +569,6 @@ const SearchPage: FC<DefaultSeoInfo> = ({ url, canonicalUrl }) => {
 				break;
 			}
 
-			case SearchFilterId.ConsultablePublicDomain:
-				// Info: remove query param if false (= set to undefined)
-				data =
-					(values as ConsultablePublicDomainFilterFormState)[
-						IeObjectsSearchFilterField.CONSULTABLE_PUBLIC_DOMAIN
-					] || undefined;
-				break;
-
 			case SearchFilterId.Advanced:
 				data = (values as AdvancedFilterFormState).advanced.filter((advanced) => {
 					return !isNil(advanced.val) && advanced.val !== initialFields().val;
@@ -636,8 +627,7 @@ const SearchPage: FC<DefaultSeoInfo> = ({ url, canonicalUrl }) => {
 					break;
 
 				case SearchFilterId.ConsultableOnlyOnLocation:
-				case SearchFilterId.ConsultableMedia:
-				case SearchFilterId.ConsultablePublicDomain: {
+				case SearchFilterId.ConsultableMedia: {
 					// eslint-disable-next-line no-case-declarations
 					const newValue = `${tag.value ?? 'false'}`.replace(tagPrefix(tag.key), '');
 					updatedQuery[tag.key] = newValue === 'true' ? 'false' : 'true';

--- a/src/modules/visitor-space/const/visitor-space-filters.const.tsx
+++ b/src/modules/visitor-space/const/visitor-space-filters.const.tsx
@@ -5,7 +5,6 @@ import { SearchPageMediaType } from '@shared/types/ie-objects';
 import { AdvancedFilterForm } from '@visitor-space/components/AdvancedFilterForm/AdvancedFilterForm';
 import { ConsultableMediaFilterForm } from '@visitor-space/components/ConsultableMediaFilterForm/ConsultableMediaFilterForm';
 import { ConsultableOnlyOnLocationFilterForm } from '@visitor-space/components/ConsultableOnlyOnLocationFilterForm/ConsultableOnlyOnLocationFilterForm';
-import { ConsultablePublicDomainFilterForm } from '@visitor-space/components/ConsultablePublicDomainFilterForm/ConsultablePublicDomainFilterForm';
 import { CreatorFilterForm } from '@visitor-space/components/CreatorFilterForm/CreatorFilterForm';
 import {
 	type FilterMenuFilterOption,
@@ -113,16 +112,6 @@ export const SEARCH_PAGE_FILTERS = (
 		form: ReleaseDateFilterForm,
 		type: FilterMenuType.Modal,
 		tabs: ALL_TABS,
-	},
-	{
-		id: SearchFilterId.ConsultablePublicDomain,
-		label: tText('modules/visitor-space/const/visitor-space-filters___publiek-domain'),
-		form: ConsultablePublicDomainFilterForm,
-		type: FilterMenuType.Checkbox,
-		tabs: ALL_TABS,
-		isDisabled: () => {
-			return !isGlobalArchive || !isKeyUser;
-		},
 	},
 	{
 		id: SearchFilterId.Reusability,

--- a/src/modules/visitor-space/utils/elastic-filters/elastic-filters.ts
+++ b/src/modules/visitor-space/utils/elastic-filters/elastic-filters.ts
@@ -173,13 +173,7 @@ export const mapFiltersToElastic = (query: SearchPageQueryParams): IeObjectsSear
 			operator: IeObjectsSearchOperator.IS,
 			value: query[SearchFilterId.ConsultableMedia] ? 'true' : '',
 		},
-		// Consultable Public Domain
-		{
-			field: IeObjectsSearchFilterField.CONSULTABLE_PUBLIC_DOMAIN,
-			operator: IeObjectsSearchOperator.IS,
-			value: query[SearchFilterId.ConsultablePublicDomain] ? 'true' : '',
-		},
-		// Reusability
+// Reusability
 		{
 			field: IeObjectsSearchFilterField.REUSABILITY,
 			operator: IeObjectsSearchOperator.IS,

--- a/src/modules/visitor-space/utils/map-filters/map-filters.tsx
+++ b/src/modules/visitor-space/utils/map-filters/map-filters.tsx
@@ -214,12 +214,7 @@ export const mapFiltersToTags = (query: SearchPageQueryParams): TagIdentity[] =>
 			tText('modules/visitor-space/utils/map-filters/map-filters___alles-wat-raadpleegbaar-is'),
 			SearchFilterId.ConsultableMedia
 		),
-		...mapBooleanParamToTag(
-			query[SearchFilterId.ConsultablePublicDomain] || false,
-			tText('modules/visitor-space/utils/map-filters/map-filters___publiek-domain'),
-			SearchFilterId.ConsultablePublicDomain
-		),
-		...mapArrayParamToTags(
+...mapArrayParamToTags(
 			query[SearchFilterId.Maintainers] || [],
 			tText('modules/visitor-space/utils/map-filters/map-filters___aanbieders'),
 			SearchFilterId.Maintainers


### PR DESCRIPTION
## Summary

Per FA `HA2-FA_Zoek-overzicht_Filter_Herbruikbaarheid`:

> "Deze filter vervangt de filter **'Publiek domein'** op Kranten. Deze wordt dus **verwijderd.**"

- Removed `ConsultablePublicDomain` from the filter menu config (`visitor-space-filters.const.tsx`)
- Removed submit handler and tag removal case from `SearchPage.tsx`
- Removed tag mapping from `map-filters.tsx`
- Removed Elasticsearch filter from `elastic-filters.ts`
- Kept the enum value and query param config for backwards compatibility (existing bookmarked URLs won't break)

## Test plan

- [ ] Open the search page on the Kranten tab — verify "Publiek domein" checkbox filter no longer appears
- [ ] Verify the Herbruikbaarheid filter still works correctly on all tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)