### PR TITLE
fix: spacing between focus bar and first column in documents table

### DIFF
--- a/src/modules/account/components/MaterialRequestDetailBlade/MaterialRequestDocuments.module.scss
+++ b/src/modules/account/components/MaterialRequestDetailBlade/MaterialRequestDocuments.module.scss
@@ -14,7 +14,6 @@
 			font-size: abstracts.$font-size-base;
 			line-height: abstracts.$line-height-base;
 			text-align: left;
-			padding-left: 0;
 
 			@media (max-width: abstracts.$breakpoint-md) {
 				padding: abstracts.$spacer-sm 0;


### PR DESCRIPTION
**Before:**
<img width="2626" height="500" alt="image" src="https://github.com/user-attachments/assets/f229e801-500b-49da-af1d-8ecff396ed41" />


**After:**
<img width="2642" height="472" alt="image" src="https://github.com/user-attachments/assets/32e37fc2-8001-42b6-bf1d-b4dff5e527b6" />