### PR TITLE
fix: reuseability filter visibility

### DIFF
--- a/src/modules/visitor-space/const/visitor-space-filters.const.tsx
+++ b/src/modules/visitor-space/const/visitor-space-filters.const.tsx
@@ -121,7 +121,7 @@ export const SEARCH_PAGE_FILTERS = (
 		tabs: ALL_TABS,
 		isDisabled: () => {
 			const rightsFiltersForEverybody =
-				publicRuntimeConfig.ENABLE_RIGHTS_FILTERS_FOR_EVERYBODY === 'true';
+				publicRuntimeConfig.ENABLE_RIGHTS_FILTERS_FOR_EVERYBODY !== 'false';
 			return !rightsFiltersForEverybody && !isKeyUser;
 		},
 	},


### PR DESCRIPTION
@bertyhell @reunefe 

Denk dat dit het issue wel fixed, maar weet niet hoe veilig dit is?

Want als die ENABLE_RIGHTS_FILTERS_FOR_EVERYBODY dan volledig niet geladen is i.p.v. gewoon laat, of die ontbreekt ofzo, dan gaat de filter wel gewoon zichtbaar zijn nog.

Ik weet niet of dit kan voorvallen? Als dat geen probleem is zou dit genoeg moeten zijn :) 

https://github.com/user-attachments/assets/b0a30559-5944-4c05-b875-da3ce0745fbb



