### PR TITLE
fix(ARC-3718): truncate long cta on mobile.

### DIFF
--- a/src/modules/account/components/MaterialRequestDetailBlade/MaterialRequestDetailBlade.module.scss
+++ b/src/modules/account/components/MaterialRequestDetailBlade/MaterialRequestDetailBlade.module.scss
@@ -136,6 +136,27 @@
 
 		@media (max-width: abstracts.$breakpoint-md) {
 			align-items: center;
+			gap: abstracts.$spacer-xs;
+
+			:global(.c-button) {
+				flex: 1 1 0;
+				width: 0;
+				min-width: 0;
+				max-width: 100%;
+			}
+
+			:global(.c-button__content) {
+				width: 100%;
+				min-width: 0;
+				max-width: 100%;
+			}
+
+			:global(.c-button__label) {
+				width: 100%;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+			}
 
 			&:has(.p-material-request-detail__download-message) {
 				flex-direction: column;


### PR DESCRIPTION
**Before:**
<img width="800" height="1594" alt="image" src="https://github.com/user-attachments/assets/26dbeaea-41d9-4f51-8e1a-6ab46e827fb2" />

**After:**
<img width="790" height="1610" alt="image" src="https://github.com/user-attachments/assets/0212b9c7-ce93-4abd-9a85-2c8e6fe5841c" />
