### PR TITLE
fix: fix source tooltip font size

### DIFF
--- a/src/styles/components/_tooltip.scss
+++ b/src/styles/components/_tooltip.scss
@@ -14,6 +14,11 @@
 		opacity 0.2s ease-in-out,
 		visibility 0.2s linear 0.2s;
 
+	p {
+		font-size: inherit;
+		line-height: inherit;
+	}
+
 	&-trigger {
 		display: inline-block !important;
 	}


### PR DESCRIPTION
Die nam <p> styling mee van uit de translations.

Before:
<img width="374" height="239" alt="image" src="https://github.com/user-attachments/assets/59254762-f3e3-48c4-966f-a293daaaf193" />

After:
<img width="370" height="226" alt="image" src="https://github.com/user-attachments/assets/8700d0f2-24dd-40f9-b847-c3ba196f6e14" />

