### PR TITLE
fix(ARC-3599): fix rights for A/V objects, increase select menu height

### DIFF
--- a/src/modules/ie-objects/ie-objects.types.ts
+++ b/src/modules/ie-objects/ie-objects.types.ts
@@ -230,7 +230,8 @@ type aggregateKeys =
 	| ElasticsearchFieldNames.Genre
 	| ElasticsearchFieldNames.Language
 	| ElasticsearchFieldNames.Maintainer
-	| ElasticsearchFieldNames.Rights;
+	| ElasticsearchFieldNames.RightsForNewspaper
+	| ElasticsearchFieldNames.RightsForAudioVideo;
 
 export type IeObjectSearchAggregations = Record<aggregateKeys, IeObjectSearchAggregation<string>>;
 

--- a/src/modules/shared/types/ie-objects.ts
+++ b/src/modules/shared/types/ie-objects.ts
@@ -48,8 +48,8 @@ export enum IeObjectsSearchFilterField {
 	CONSULTABLE_ONLY_ON_LOCATION = 'isConsultableOnlyOnLocation',
 	CONSULTABLE_MEDIA = 'isConsultableMedia',
 	CONSULTABLE_PUBLIC_DOMAIN = 'isConsultablePublicDomain',
-	REUSABILITY = 'reusability',
-	RIGHTS = 'rights',
+	REUSABILITY = 'reusability', // free, conditional, maybe
+	RIGHTS = 'rights', // Single term to cover both newspaper rights (dcterms_rights_statement) and Audio/Video object rights (reuse_category.id)
 	CAST = 'cast',
 	IDENTIFIER = 'identifier',
 	OBJECT_TYPE = 'objectType',

--- a/src/modules/visitor-space/components/AdvancedFilterFields/AdvancedFilterFields.module.scss
+++ b/src/modules/visitor-space/components/AdvancedFilterFields/AdvancedFilterFields.module.scss
@@ -1,16 +1,16 @@
 @use "sass:color";
-@use "src/styles/abstracts" as *;
+@use "src/styles/abstracts" as abstracts;
 
 .c-advanced-filter-fields {
 	display: grid;
 	grid-template-columns: repeat(2, 1fr);
-	gap: $spacer-sm;
+	gap: abstracts.$spacer-sm;
 	padding: 2rem;
-	border-bottom: 1px solid color.adjust($black, $alpha: -0.8);
-	background-color: $platinum;
+	border-bottom: 1px solid color.adjust(abstracts.$black, $alpha: -0.8);
+	background-color: abstracts.$platinum;
 
-	@media (min-width: $breakpoint-md) {
-		padding: $spacer-lg;
+	@media (min-width: abstracts.$breakpoint-md) {
+		padding: abstracts.$spacer-lg;
 	}
 }
 
@@ -21,7 +21,7 @@
 		display: flex;
 
 		:global(.c-button) {
-			margin-left: $spacer-sm;
+			margin-left: abstracts.$spacer-sm;
 			flex-shrink: 0;
 		}
 	}

--- a/src/modules/visitor-space/components/AdvancedFilterForm/AdvancedFilterForm.module.scss
+++ b/src/modules/visitor-space/components/AdvancedFilterForm/AdvancedFilterForm.module.scss
@@ -1,7 +1,5 @@
 @use "src/styles/abstracts" as *;
 
-$component: "advancedFilterForm";
-
-.#{$component} {
+.advancedFilterForm {
 	min-height: 32rem;
 }

--- a/src/modules/visitor-space/components/AdvancedRightsSelect/AdvancedRightsSelect.tsx
+++ b/src/modules/visitor-space/components/AdvancedRightsSelect/AdvancedRightsSelect.tsx
@@ -17,7 +17,7 @@ export const AdvancedRightsSelect: FC<ReactSelectProps> = (props) => {
 	);
 
 	// Combine buckets from both aggregation types (dcterms_rights_statement for newspapers,
-	// reuse_category.id for audio/video). Normalise to uppercase to match the RightsLabel enum.
+	// reuse_category.id for audio/video). Match values case-insensitively against the RightsLabel enum.
 	const allRightsLabels = Object.values(RightsLabel) as string[];
 	const availableRightsValues = [
 		...(searchAggregateOptions?.[ElasticsearchFieldNames.RightsForNewspaper]?.buckets || []),

--- a/src/modules/visitor-space/components/AdvancedRightsSelect/AdvancedRightsSelect.tsx
+++ b/src/modules/visitor-space/components/AdvancedRightsSelect/AdvancedRightsSelect.tsx
@@ -2,7 +2,7 @@ import type { IeObjectSearchAggregations } from '@ie-objects/ie-objects.types';
 import { ReactSelect, type ReactSelectProps } from '@meemoo/react-components';
 import { selectIeObjectsFilterOptions } from '@shared/store/ie-objects';
 import { SEARCH_PAGE_QUERY_PARAM_CONFIG } from '@visitor-space/const';
-import { getRightsOptions, type RightsLabel } from '@visitor-space/const/rights-filter.const';
+import { getRightsOptions, RightsLabel } from '@visitor-space/const/rights-filter.const';
 import { ElasticsearchFieldNames, SearchFilterId } from '@visitor-space/types';
 import type { FC } from 'react';
 import { useSelector } from 'react-redux';
@@ -15,10 +15,23 @@ export const AdvancedRightsSelect: FC<ReactSelectProps> = (props) => {
 	const searchAggregateOptions: IeObjectSearchAggregations | undefined = useSelector(
 		selectIeObjectsFilterOptions
 	);
-	const availableRightsValues =
-		searchAggregateOptions?.[ElasticsearchFieldNames.Rights]?.buckets?.map(
-			(bucket) => bucket.key as RightsLabel
-		) || [];
+
+	// Combine buckets from both aggregation types (dcterms_rights_statement for newspapers,
+	// reuse_category.id for audio/video). Normalise to uppercase to match the RightsLabel enum.
+	const allRightsLabels = Object.values(RightsLabel) as string[];
+	const availableRightsValues = [
+		...(searchAggregateOptions?.[ElasticsearchFieldNames.RightsForNewspaper]?.buckets || []),
+		...(searchAggregateOptions?.[ElasticsearchFieldNames.RightsForAudioVideo]?.buckets || []),
+	].reduce<RightsLabel[]>((acc, bucket) => {
+		const match = allRightsLabels.find(
+			(label) => label.toLowerCase() === (bucket.key as string).toLowerCase()
+		) as RightsLabel | undefined;
+		if (match && !acc.includes(match)) {
+			acc.push(match);
+		}
+		return acc;
+	}, []);
+
 	const options = getRightsOptions(selectedRightsValues, availableRightsValues);
 	const selectedValue = (props.value as SingleValue<{ label: string; value: string }>)?.value;
 

--- a/src/modules/visitor-space/components/FilterMenu/FilterForm/FilterForm.module.scss
+++ b/src/modules/visitor-space/components/FilterMenu/FilterForm/FilterForm.module.scss
@@ -48,7 +48,7 @@
 	// Ensure dropdowns fit in the minimal body (1 default field & add-new button)
 	:global(.c-react-select__menu-list) {
 		overflow: auto;
-		max-height: $spacer-1xl * 4;
+		max-height: $spacer-1xl * 6;
 	}
 
 	&--overflow {

--- a/src/modules/visitor-space/components/FilterMenu/FilterOption/FilterOption.tsx
+++ b/src/modules/visitor-space/components/FilterMenu/FilterOption/FilterOption.tsx
@@ -80,7 +80,7 @@ const FilterOption: FC<FilterOptionProps> = ({
 		[SearchFilterId.Language]: '53.7rem',
 		[SearchFilterId.Maintainers]: '63.7rem',
 		[SearchFilterId.Reusability]: '20rem',
-		[SearchFilterId.Advanced]: '60.1rem',
+		[SearchFilterId.Advanced]: '80rem',
 	};
 	const renderModal = (): ReactElement => {
 		return (

--- a/src/modules/visitor-space/const/rights-filter.const.ts
+++ b/src/modules/visitor-space/const/rights-filter.const.ts
@@ -1,6 +1,6 @@
 import type { SelectOption } from '@meemoo/react-components';
 import { tText } from '@shared/helpers/translate';
-import { compact, uniqBy } from 'lodash-es';
+import { compact, sortBy, uniqBy } from 'lodash-es';
 
 export enum RightsLabel {
 	PUBLIC_DOMAIN = 'https://creativecommons.org/publicdomain/mark/1.0/',
@@ -99,5 +99,7 @@ export const getRightsOptions = (
 	const selectedOptions = selectedReusabilityValues.map((value) => {
 		return allOptions.find((option) => option.value === value);
 	});
-	return uniqBy(compact([...selectedOptions, ...availableOptions]), (option) => option.value);
+	const rights = compact([...selectedOptions, ...availableOptions]);
+	const uniqueRights = uniqBy(rights, (option) => option.value);
+	return sortBy(uniqueRights, (option) => option.label);
 };

--- a/src/modules/visitor-space/types/index.ts
+++ b/src/modules/visitor-space/types/index.ts
@@ -57,7 +57,8 @@ export enum ElasticsearchFieldNames {
 	Format = 'dcterms_format',
 	ObjectType = 'ebucore_object_type',
 	Maintainer = 'schema_maintainer.schema_identifier',
-	Rights = 'dcterms_rights_statement',
+	RightsForNewspaper = 'dcterms_rights_statement',
+	RightsForAudioVideo = 'reuse_category.id',
 }
 
 export enum VisitorSpaceOrderProps {

--- a/src/styles/abstracts/_mixins.scss
+++ b/src/styles/abstracts/_mixins.scss
@@ -251,42 +251,6 @@
 	.#{$_root}__value-container {
 		padding-left: variables.$spacer-sm;
 	}
-
-	.#{$_root}__menu {
-		border: 1px solid variables.$zinc;
-		border-top: none;
-		margin: 0;
-		border-radius: 0;
-		box-shadow: none;
-	}
-
-	.#{$_root}__menu-list {
-		padding: 0;
-	}
-
-	.#{$_root}__option {
-		border-right: 4px solid transparent;
-		color: variables.$black;
-		transition:
-			background-color variables.$animate-default,
-			border-color variables.$animate-default,
-			border-right-width variables.$animate-sm-in;
-
-		&--is-focused,
-		&--is-selected,
-		&:not(&--is-selected):hover {
-			background-color: color.adjust(variables.$teal, $alpha: -0.76);
-		}
-
-		&--is-selected {
-			border-color: variables.$teal;
-
-			&.#{$_root}__option--is-focused,
-			&:hover {
-				border-right-width: 6px;
-			}
-		}
-	}
 }
 
 /**

--- a/src/styles/abstracts/_variables.scss
+++ b/src/styles/abstracts/_variables.scss
@@ -140,6 +140,7 @@ $breakpoint-xxl: 1400px;
  */
 
 $z-layers: (
+	"dropdown": 10,
 	"modal": 9,
 	"blade": 8,
 	"alerts": 2,

--- a/src/styles/components/_react-select.scss
+++ b/src/styles/components/_react-select.scss
@@ -39,6 +39,7 @@
 			border-color: abstracts.$teal;
 
 			&.c-react-select__option--is-focused,
+			&.c-tags-input__option--is-focused,
 			&:hover {
 				border-right-width: 6px;
 			}

--- a/src/styles/components/_react-select.scss
+++ b/src/styles/components/_react-select.scss
@@ -1,5 +1,47 @@
-@use "../abstracts" as *;
+@use "sass:color";
+@use "../abstracts" as abstracts;
 
 .c-react-select {
-	@include react-select-base("c-react-select");
+	@include abstracts.react-select-base("c-react-select");
+}
+
+.c-tags-input__menu-portal,
+.c-react-select__menu-portal {
+	.c-tags-input__menu,
+	.c-react-select__menu {
+		border: 1px solid abstracts.$zinc;
+		border-top: none;
+		margin: 0;
+		border-radius: 0;
+		box-shadow: none;
+	}
+
+	.c-tags-input__menu-list,
+	.c-react-select__menu-list {
+		padding: 0;
+	}
+
+	.c-tags-input__option,
+	.c-react-select__option {
+		border-right: 4px solid transparent;
+		color: abstracts.$black;
+		transition: background-color abstracts.$animate-default,
+		border-color abstracts.$animate-default,
+		border-right-width abstracts.$animate-sm-in;
+
+		&--is-focused,
+		&--is-selected,
+		&:not(&--is-selected):hover {
+			background-color: color.adjust(abstracts.$teal, $alpha: -0.76);
+		}
+
+		&--is-selected {
+			border-color: abstracts.$teal;
+
+			&.c-react-select__option--is-focused,
+			&:hover {
+				border-right-width: 6px;
+			}
+		}
+	}
 }

--- a/src/styles/components/_tags-input.scss
+++ b/src/styles/components/_tags-input.scss
@@ -1,5 +1,5 @@
 @use "sass:color";
-@use "../abstracts" as *;
+@use "../abstracts" as abstracts;
 
 // Wrap everything for higher specificity
 .c-tags-input {
@@ -7,14 +7,14 @@
 	* Elements
 	*/
 
-	@include react-select-base("c-tags-input");
+	@include abstracts.react-select-base("c-tags-input");
 
 	.c-tags-input__control {
 		cursor: text;
 
 		.c-tags-input__value-container .c-tags-input__multi-value {
-			margin: $spacer-xxs $spacer-xs $spacer-xxs 0;
-			font-size: $font-size-sm;
+			margin: abstracts.$spacer-xxs abstracts.$spacer-xs abstracts.$spacer-xxs 0;
+			font-size: abstracts.$font-size-sm;
 			background-color: transparent;
 			border: none;
 			border-radius: 0;
@@ -27,8 +27,8 @@
 			color: inherit;
 			word-break: break-word;
 
-			@media (min-width: $breakpoint-md) {
-				margin: $spacer-xxs $spacer-sm $spacer-xxs 0;
+			@media (min-width: abstracts.$breakpoint-md) {
+				margin: abstracts.$spacer-xxs abstracts.$spacer-sm abstracts.$spacer-xxs 0;
 			}
 		}
 	}
@@ -38,7 +38,7 @@
 		padding: 0.6rem;
 
 		&:not(:active, :hover):focus {
-			outline: 2px solid $teal;
+			outline: 2px solid abstracts.$teal;
 			border-radius: 0.5rem;
 		}
 	}
@@ -48,7 +48,7 @@
 		cursor: pointer;
 
 		&:hover {
-			color: color.adjust($black, $alpha: -0.5);
+			color: color.adjust(abstracts.$black, $alpha: -0.5);
 		}
 	}
 
@@ -60,13 +60,13 @@
 			display: flex;
 			width: 0.15rem;
 			height: 3.5rem;
-			margin: 0 $spacer-sm;
+			margin: 0 abstracts.$spacer-sm;
 			border-radius: 0.15rem;
-			background-color: $black;
+			background-color: abstracts.$black;
 			opacity: 0.12;
 		}
 
-		@media (min-width: $breakpoint-md) {
+		@media (min-width: abstracts.$breakpoint-md) {
 			margin-right: 0;
 
 			&::after {
@@ -76,8 +76,8 @@
 	}
 
 	.c-tags-input__indicator-icon {
-		font-size: $font-size-lg;
-		transition: color $animate-sm-in;
-		color: $neutral;
+		font-size: abstracts.$font-size-lg;
+		transition: color abstracts.$animate-sm-in;
+		color: abstracts.$neutral;
 	}
 }


### PR DESCRIPTION
https://meemoo.atlassian.net/browse/ARC-3599

show rights for newspapers and audio/video objects in the same rights advanced filter
<img width="2550" height="1393" alt="image" src="https://github.com/user-attachments/assets/245a9638-c2f3-4fce-980b-b880f6e217d1" />
<img width="2550" height="1393" alt="image" src="https://github.com/user-attachments/assets/36536361-7636-4e06-a588-b20f7beb000a" />
<img width="2550" height="1393" alt="image" src="https://github.com/user-attachments/assets/3028de3c-9cda-48c4-88e2-538d1902f924" />
<img width="2550" height="1393" alt="image" src="https://github.com/user-attachments/assets/5f544995-8659-4bea-a3b5-7e430e4961de" />
<img width="2550" height="1393" alt="image" src="https://github.com/user-attachments/assets/b7c4c9f0-ca0f-479a-8cd5-cb0a6b7a7005" />
<img width="2550" height="1393" alt="image" src="https://github.com/user-attachments/assets/e4d86467-e786-45d3-a8a2-60ba18986e58" />



also fix the select menu height and overflow issues
includes a change in the react-components: https://github.com/viaacode/react-components/commit/69ee8ec22f6feba6c1ec4f1d6bc81759a90857e5
before:
<img width="2550" height="1393" alt="image" src="https://github.com/user-attachments/assets/3a578cad-f488-4aac-9413-5815e1e93cde" />

after:
<img width="2550" height="1393" alt="image" src="https://github.com/user-attachments/assets/fd26c368-4c1b-4002-8bd4-794f8d73120e" />

