### PR TITLE
Adds client search URL conversion to admin-core

### DIFF
--- a/src/modules/admin/wrappers/admin-core-config.tsx
+++ b/src/modules/admin/wrappers/admin-core-config.tsx
@@ -23,6 +23,7 @@ import { ApiService } from '@shared/services/api-service';
 import { toastService } from '@shared/services/toast-service';
 import type { Locale } from '@shared/utils/i18n';
 import { AvoCoreDatabaseType, type AvoUserCommonUser } from '@viaa/avo2-types';
+import { searchUrlToApiUrl } from '@visitor-space/utils/search-url-to-api-url/search-url-to-api-url';
 import Link from 'next/link';
 import type { NextRouter } from 'next/router';
 import { stringifyUrl } from 'query-string';
@@ -96,7 +97,9 @@ export function getAdminCoreConfig(
 			customNavigationElements: [NAVIGATION_DROPDOWN.VISITOR_SPACES],
 		},
 		icon: {
-			component: ({ name }: { name: string }) => <Icon name={name as IconName} />,
+			component: ({ name, className }: { name: string; className?: string }) => (
+				<Icon name={name as IconName} className={className} />
+			),
 			componentProps: {
 				add: { name: IconNamesLight.Plus },
 				angleDown: { name: IconNamesLight.AngleDown },
@@ -210,6 +213,9 @@ export function getAdminCoreConfig(
 				clear: async (_key: string) => Promise.resolve(),
 			},
 			getContentPageByLanguageAndPathEndpoint: null,
+			search: {
+				clientSearchUrlToApiSearchUrl: searchUrlToApiUrl,
+			},
 		},
 		database: {
 			proxyUrl: publicRuntimeConfig.PROXY_URL,

--- a/src/modules/admin/wrappers/admin-core-config.tsx
+++ b/src/modules/admin/wrappers/admin-core-config.tsx
@@ -23,7 +23,7 @@ import { ApiService } from '@shared/services/api-service';
 import { toastService } from '@shared/services/toast-service';
 import type { Locale } from '@shared/utils/i18n';
 import { AvoCoreDatabaseType, type AvoUserCommonUser } from '@viaa/avo2-types';
-import { searchUrlToApiUrl } from '@visitor-space/utils/search-url-to-api-url/search-url-to-api-url';
+import { clientSearchUrlToApiSearchUrl } from '@visitor-space/utils/search-url-to-api-url/client-search-url-to-api-search-url';
 import Link from 'next/link';
 import type { NextRouter } from 'next/router';
 import { stringifyUrl } from 'query-string';
@@ -214,7 +214,7 @@ export function getAdminCoreConfig(
 			},
 			getContentPageByLanguageAndPathEndpoint: null,
 			search: {
-				clientSearchUrlToApiSearchUrl: searchUrlToApiUrl,
+				clientSearchUrlToApiSearchUrl,
 			},
 		},
 		database: {

--- a/src/modules/visitor-space/utils/search-url-to-api-url/client-search-url-to-api-search-url.ts
+++ b/src/modules/visitor-space/utils/search-url-to-api-url/client-search-url-to-api-search-url.ts
@@ -18,7 +18,7 @@ export interface IeObjectsSearchBody {
  * (`services.search.searchUrlToApiUrl`) so the admin-core package doesn't need its own port of
  * this client-side filter logic.
  */
-export const searchUrlToApiUrl = (searchQuery: string, size: number): IeObjectsSearchBody => {
+export const clientSearchUrlToApiSearchUrl = (searchQuery: string): IeObjectsSearchBody => {
 	try {
 		const url = new URL(searchQuery);
 		const encodedQuery = parseQueryString(url.search);
@@ -29,11 +29,11 @@ export const searchUrlToApiUrl = (searchQuery: string, size: number): IeObjectsS
 
 		return {
 			filters: mapFiltersToElastic(query),
-			size,
+			size: 20,
 			page: query.page || 1,
 		};
 	} catch {
 		// Invalid URL (already blocked by the editor validator) => return an empty search.
-		return { filters: [], size, page: 1 };
+		return { filters: [], size: 20, page: 1 };
 	}
 };

--- a/src/modules/visitor-space/utils/search-url-to-api-url/search-url-to-api-url.ts
+++ b/src/modules/visitor-space/utils/search-url-to-api-url/search-url-to-api-url.ts
@@ -1,0 +1,39 @@
+import type { IeObjectsSearchFilter } from '@shared/types/ie-objects';
+import { parse as parseQueryString } from 'query-string';
+import { decodeQueryParams } from 'use-query-params';
+
+import { SEARCH_PAGE_QUERY_PARAM_CONFIG, type SearchPageQueryParams } from '../../const';
+import { mapFiltersToElastic } from '../elastic-filters/elastic-filters';
+
+export interface IeObjectsSearchBody {
+	filters: IeObjectsSearchFilter[];
+	size: number;
+	page: number;
+}
+
+/**
+ * Convert a raw hetarchief `/zoeken` search URL (as stored on the ObjectsGrid content-page block)
+ * into the ie-objects search API request body, reusing the same filter mapping the search page
+ * itself uses (`mapFiltersToElastic`). Passed into the admin-core through the admin-core config
+ * (`services.search.searchUrlToApiUrl`) so the admin-core package doesn't need its own port of
+ * this client-side filter logic.
+ */
+export const searchUrlToApiUrl = (searchQuery: string, size: number): IeObjectsSearchBody => {
+	try {
+		const url = new URL(searchQuery);
+		const encodedQuery = parseQueryString(url.search);
+		const query: SearchPageQueryParams = decodeQueryParams(
+			SEARCH_PAGE_QUERY_PARAM_CONFIG,
+			encodedQuery
+		);
+
+		return {
+			filters: mapFiltersToElastic(query),
+			size,
+			page: query.page || 1,
+		};
+	} catch {
+		// Invalid URL (already blocked by the editor validator) => return an empty search.
+		return { filters: [], size, page: 1 };
+	}
+};


### PR DESCRIPTION
Introduces a utility function to convert client-side search URLs into an API-compatible request body, which is then integrated into the admin-core configuration.

This change:
- Enables the admin-core to process and utilize search URLs originating from the visitor space's ObjectsGrid content block.
- Prevents the duplication of client-side filter mapping logic within the admin-core package by reusing existing functionality.

Relates to https://meemoo.atlassian.net/browse/ARC-3792

<img width="1728" height="879" alt="2026-07-20_11-55-58" src="https://github.com/user-attachments/assets/de26d2bd-ab10-4073-962c-70e91ce79e08" />
