### PR TITLE
feat(ie-objects): show the themes section on the object detail page

### DIFF
--- a/src/modules/ie-objects/components/ObjectDetailPageMetadata/ObjectDetailPageMetadata.tsx
+++ b/src/modules/ie-objects/components/ObjectDetailPageMetadata/ObjectDetailPageMetadata.tsx
@@ -13,6 +13,7 @@ import type { MetadataItem } from '@ie-objects/components/Metadata/Metadata.type
 import { NamesList } from '@ie-objects/components/NamesList/NamesList';
 import type { ObjectDetailPageMetadataProps } from '@ie-objects/components/ObjectDetailPageMetadata/ObjectDetailPageMetadata.types';
 import { ObjectDetailPageMetadataRights } from '@ie-objects/components/ObjectDetailPageMetadata/ObjectDetailPageMetadataRights';
+import { ObjectDetailPageMetadataThemes } from '@ie-objects/components/ObjectDetailPageMetadata/ObjectDetailPageMetadataThemes';
 import { SearchLinkTag } from '@ie-objects/components/SearchLinkTag/SearchLinkTag';
 import { useGetIeObjectPreviousNextIds } from '@ie-objects/hooks/use-get-ie-object-previous-next-ids';
 import { useIsPublicNewspaper } from '@ie-objects/hooks/use-get-is-public-newspaper';
@@ -223,6 +224,14 @@ export const ObjectDetailPageMetadata: FC<ObjectDetailPageMetadataProps> = ({
 		isLoggedOutUser: !user,
 	});
 	const canDownloadMetadata: boolean = ieObjectPermissions.canExportMetadata;
+
+	// Themes are shown for publicly disclosed objects that belong to at least one theme, to every
+	// user including logged out ones, but never to kiosk visitors. See ARC-3826.
+	const themes = mediaInfo?.themes ?? [];
+	const showThemes: boolean =
+		!isKiosk &&
+		!!mediaInfo?.licenses?.includes(IeObjectLicense.PUBLIEK_CONTENT) &&
+		themes.length > 0;
 
 	// You need the permission or not to be logged in to download the newspaper
 	// https://meemoo.atlassian.net/browse/ARC-2617
@@ -1320,6 +1329,16 @@ export const ObjectDetailPageMetadata: FC<ObjectDetailPageMetadataProps> = ({
 								onZoomToMention={handleZoomToMention}
 							/>
 						</Metadata>
+					)}
+
+					{showThemes && (
+						<ObjectDetailPageMetadataThemes
+							title={tHtml(
+								'modules/ie-objects/components/object-detail-page-metadata/object-detail-page-metadata-themes___themas'
+							)}
+							themes={themes}
+							locale={locale}
+						/>
 					)}
 
 					{!!mediaInfo.keywords?.length && (

--- a/src/modules/ie-objects/components/ObjectDetailPageMetadata/ObjectDetailPageMetadataThemes.module.scss
+++ b/src/modules/ie-objects/components/ObjectDetailPageMetadata/ObjectDetailPageMetadataThemes.module.scss
@@ -1,0 +1,60 @@
+@use "src/styles/abstracts" as abstracts;
+
+.c-object-detail-page-metadata-themes {
+	&__list {
+		display: flex;
+		flex-direction: column;
+		gap: abstracts.$spacer-sm;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	// Name on the left, counter pushed to the right edge of the metadata panel
+	&__item {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: space-between;
+		gap: abstracts.$spacer-xs;
+		font-size: abstracts.$font-size-base;
+		line-height: abstracts.$line-height-1xl;
+	}
+
+	&__name {
+		color: inherit;
+
+		&--link {
+			text-decoration: underline;
+			text-underline-offset: 0.2rem;
+		}
+	}
+
+	&__count {
+		display: inline-flex;
+		flex-shrink: 0;
+		align-items: center;
+		gap: abstracts.$spacer-xxs;
+	}
+
+	// Visible to screen readers only: spells out what the bare counter means
+	&__count-label {
+		position: absolute;
+		overflow: hidden;
+		clip-path: inset(50%);
+		width: 1px;
+		height: 1px;
+		white-space: nowrap;
+	}
+
+	&__count-icon {
+		display: inline-flex;
+		align-items: center;
+		line-height: 1;
+
+		:global([class*="c-icon"]) {
+			font-size: abstracts.$font-size-1xl;
+			line-height: 1;
+		}
+	}
+}

--- a/src/modules/ie-objects/components/ObjectDetailPageMetadata/ObjectDetailPageMetadataThemes.module.scss
+++ b/src/modules/ie-objects/components/ObjectDetailPageMetadata/ObjectDetailPageMetadataThemes.module.scss
@@ -22,8 +22,6 @@
 	}
 
 	&__name {
-		color: inherit;
-
 		&--link {
 			text-decoration: underline;
 			text-underline-offset: 0.2rem;
@@ -35,6 +33,14 @@
 		flex-shrink: 0;
 		align-items: center;
 		gap: abstracts.$spacer-xxs;
+
+		// Keeps the counter against the right edge once a long theme name pushes it onto its own row
+		margin-left: auto;
+
+		@include abstracts.module-class-selector("Icon", "c-icon") {
+			font-size: abstracts.$font-size-1xl;
+			line-height: 1;
+		}
 	}
 
 	// Visible to screen readers only: spells out what the bare counter means
@@ -47,14 +53,4 @@
 		white-space: nowrap;
 	}
 
-	&__count-icon {
-		display: inline-flex;
-		align-items: center;
-		line-height: 1;
-
-		:global([class*="c-icon"]) {
-			font-size: abstracts.$font-size-1xl;
-			line-height: 1;
-		}
-	}
 }

--- a/src/modules/ie-objects/components/ObjectDetailPageMetadata/ObjectDetailPageMetadataThemes.test.tsx
+++ b/src/modules/ie-objects/components/ObjectDetailPageMetadata/ObjectDetailPageMetadataThemes.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, within } from '@testing-library/react';
+
+import '@testing-library/jest-dom';
+import type { IeObjectTheme } from '@ie-objects/ie-objects.types';
+import { Locale } from '@shared/utils/i18n';
+import { describe, expect, it } from 'vitest';
+
+import { ObjectDetailPageMetadataThemes } from './ObjectDetailPageMetadataThemes';
+
+const pukkelpop: IeObjectTheme = {
+	id: '7c4f8d1a-9b2e-4c3d-8a1f-2e5b6c7d8e9f',
+	slug: 'pukkelpop',
+	nameNl: 'Pukkelpop',
+	nameEn: 'Pukkelpop festival',
+	contentPagePathNl: '/themas/pukkelpop',
+	contentPagePathEn: '/themes/pukkelpop',
+	ieObjectCount: 150,
+};
+
+const memorial: IeObjectTheme = {
+	id: '3a1b2c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d',
+	slug: 'memorial-van-damme',
+	nameNl: 'Memorial Van Damme',
+	nameEn: 'Memorial Van Damme',
+	contentPagePathNl: null,
+	contentPagePathEn: null,
+	ieObjectCount: 42,
+};
+
+describe('Component: <ObjectDetailPageMetadataThemes />', () => {
+	it('links the theme name to the Dutch theme detail page', () => {
+		render(
+			<ObjectDetailPageMetadataThemes title="Thema's" themes={[pukkelpop]} locale={Locale.nl} />
+		);
+
+		expect(screen.getByText("Thema's")).toBeInTheDocument();
+		expect(screen.getByRole('link', { name: 'Pukkelpop' })).toHaveAttribute(
+			'href',
+			'/themas/pukkelpop'
+		);
+	});
+
+	it('uses the English name and path when the UI language is English', () => {
+		render(
+			<ObjectDetailPageMetadataThemes title="Themes" themes={[pukkelpop]} locale={Locale.en} />
+		);
+
+		expect(screen.getByRole('link', { name: 'Pukkelpop festival' })).toHaveAttribute(
+			'href',
+			'/themes/pukkelpop'
+		);
+	});
+
+	it('renders the name as plain text when the theme has no detail page', () => {
+		const { container } = render(
+			<ObjectDetailPageMetadataThemes title="Thema's" themes={[memorial]} locale={Locale.nl} />
+		);
+
+		expect(screen.getByText('Memorial Van Damme')).toBeInTheDocument();
+		expect(container.querySelector('a')).not.toBeInTheDocument();
+	});
+
+	it('shows the linked object count per theme, keeping the given order', () => {
+		render(
+			<ObjectDetailPageMetadataThemes
+				title="Thema's"
+				themes={[pukkelpop, memorial]}
+				locale={Locale.nl}
+			/>
+		);
+
+		const items = screen.getAllByRole('listitem');
+		expect(items).toHaveLength(2);
+		expect(within(items[0]).getByText('150')).toBeInTheDocument();
+		expect(within(items[1]).getByText('42')).toBeInTheDocument();
+	});
+});

--- a/src/modules/ie-objects/components/ObjectDetailPageMetadata/ObjectDetailPageMetadataThemes.tsx
+++ b/src/modules/ie-objects/components/ObjectDetailPageMetadata/ObjectDetailPageMetadataThemes.tsx
@@ -1,0 +1,79 @@
+import Metadata from '@ie-objects/components/Metadata/Metadata';
+import type { IeObjectTheme } from '@ie-objects/ie-objects.types';
+import { Icon } from '@shared/components/Icon';
+import { IconNamesLight } from '@shared/components/Icon/Icon.enums';
+import { tText } from '@shared/helpers/translate';
+import { Locale } from '@shared/utils/i18n';
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+
+import styles from './ObjectDetailPageMetadataThemes.module.scss';
+
+export interface ObjectDetailPageMetadataThemesProps {
+	title: ReactNode;
+	themes: IeObjectTheme[];
+	locale: Locale;
+	className?: string;
+}
+
+/**
+ * The "Thema's" section of the metadata panel on an object detail page. See ARC-3826.
+ *
+ * Themes arrive sorted by linked object count descending. Per theme we show its name, linking to
+ * the theme detail page when one is configured, and the number of objects that carry the theme.
+ */
+export function ObjectDetailPageMetadataThemes({
+	title,
+	themes,
+	locale,
+	className,
+}: ObjectDetailPageMetadataThemesProps) {
+	const renderThemeName = (theme: IeObjectTheme) => {
+		const name = locale === Locale.en ? theme.nameEn : theme.nameNl;
+		const path = locale === Locale.en ? theme.contentPagePathEn : theme.contentPagePathNl;
+
+		// Without a theme detail page there is nothing to link to, so the name stays plain text
+		if (!path) {
+			return <span className={styles['c-object-detail-page-metadata-themes__name']}>{name}</span>;
+		}
+
+		return (
+			<Link
+				href={path}
+				className={`${styles['c-object-detail-page-metadata-themes__name']} ${styles['c-object-detail-page-metadata-themes__name--link']}`}
+			>
+				{name}
+			</Link>
+		);
+	};
+
+	return (
+		<Metadata title={title} className={className} key="metadata-themes">
+			<ul className={styles['c-object-detail-page-metadata-themes__list']}>
+				{themes.map((theme) => (
+					<li key={theme.id} className={styles['c-object-detail-page-metadata-themes__item']}>
+						{renderThemeName(theme)}
+						{/* TODO ARC-3797: link the counter to a search filtered on this theme once the
+						    theme filter exists. Until then it is plain text. */}
+						<span className={styles['c-object-detail-page-metadata-themes__count']}>
+							<Icon
+								className={styles['c-object-detail-page-metadata-themes__count-icon']}
+								name={IconNamesLight.RelatedObjects}
+								aria-hidden
+							/>
+							{/* The bare number carries no meaning on its own, so screen readers get the
+							    spelled out label instead */}
+							<span aria-hidden>{theme.ieObjectCount}</span>
+							<span className={styles['c-object-detail-page-metadata-themes__count-label']}>
+								{tText(
+									'modules/ie-objects/components/object-detail-page-metadata/object-detail-page-metadata-themes___aantal-objecten-in-dit-thema',
+									{ count: theme.ieObjectCount }
+								)}
+							</span>
+						</span>
+					</li>
+				))}
+			</ul>
+		</Metadata>
+	);
+}

--- a/src/modules/ie-objects/components/ObjectDetailPageMetadata/ObjectDetailPageMetadataThemes.tsx
+++ b/src/modules/ie-objects/components/ObjectDetailPageMetadata/ObjectDetailPageMetadataThemes.tsx
@@ -4,6 +4,7 @@ import { Icon } from '@shared/components/Icon';
 import { IconNamesLight } from '@shared/components/Icon/Icon.enums';
 import { tText } from '@shared/helpers/translate';
 import { Locale } from '@shared/utils/i18n';
+import clsx from 'clsx';
 import Link from 'next/link';
 import type { ReactNode } from 'react';
 
@@ -40,7 +41,10 @@ export function ObjectDetailPageMetadataThemes({
 		return (
 			<Link
 				href={path}
-				className={`${styles['c-object-detail-page-metadata-themes__name']} ${styles['c-object-detail-page-metadata-themes__name--link']}`}
+				className={clsx(
+					styles['c-object-detail-page-metadata-themes__name'],
+					styles['c-object-detail-page-metadata-themes__name--link']
+				)}
 			>
 				{name}
 			</Link>
@@ -56,11 +60,7 @@ export function ObjectDetailPageMetadataThemes({
 						{/* TODO ARC-3797: link the counter to a search filtered on this theme once the
 						    theme filter exists. Until then it is plain text. */}
 						<span className={styles['c-object-detail-page-metadata-themes__count']}>
-							<Icon
-								className={styles['c-object-detail-page-metadata-themes__count-icon']}
-								name={IconNamesLight.RelatedObjects}
-								aria-hidden
-							/>
+							<Icon name={IconNamesLight.RelatedObjects} aria-hidden />
 							{/* The bare number carries no meaning on its own, so screen readers get the
 							    spelled out label instead */}
 							<span aria-hidden>{theme.ieObjectCount}</span>

--- a/src/modules/ie-objects/ie-objects.types.ts
+++ b/src/modules/ie-objects/ie-objects.types.ts
@@ -30,6 +30,23 @@ export interface IsPartOfCollection {
 	publisher?: any;
 }
 
+/**
+ * A theme this object belongs to, shown in the metadata panel of the detail page. See ARC-3826.
+ * Names and content page paths come in both languages; pick the one matching the UI language.
+ */
+export interface IeObjectTheme {
+	id: string;
+	/** Only used in content management, never shown in the front end */
+	slug: string;
+	nameNl: string;
+	nameEn: string;
+	/** Internal path on hetarchief.be to the theme detail page, null when not configured */
+	contentPagePathNl: string | null;
+	contentPagePathEn: string | null;
+	/** Total number of objects linked to this theme */
+	ieObjectCount: number;
+}
+
 export interface IeObject {
 	dctermsAvailable: string;
 	dctermsFormat: IeObjectType;
@@ -108,6 +125,8 @@ export interface IeObject {
 	digitizationDate?: string;
 	children?: number;
 	rightsInfo?: IeObjectRightsInfo | null;
+	/** Sorted by ieObjectCount descending by the proxy */
+	themes?: IeObjectTheme[];
 	pages?: IeObjectPage[];
 	mentions?: Mention[];
 }


### PR DESCRIPTION
Implements the frontend half of [ARC-3826](https://meemoo.atlassian.net/browse/ARC-3826) — a "Thema's" section in the metadata panel of an object detail page.

Stacked on `feature/ARC-3798_themes-beheer-overzicht` (PR #1606), so this PR is a single commit. Merge that one first. Needs proxy PR viaacode/hetarchief-proxy#710 for the data.

## What it does

New `ObjectDetailPageMetadataThemes` component, rendered directly above "Trefwoorden".

- **Visibility** — `!isKiosk && licenses.includes(PUBLIEK_CONTENT) && themes.length > 0`. Visible to logged-out users, never to kiosk visitors.
- **Name** — in the UI language, linking to the theme detail page (`contentPagePathNl` / `contentPagePathEn`), same tab. When no path is configured it renders as plain, non-underlined, non-focusable text, per the FA.
- **Counter** — `RelatedObjects` icon plus the theme's total object count, right-aligned.
- **Order** — by linked object count descending, as returned by the proxy.
- **A11y** — semantic `ul`/`li`, `next/link` for keyboard nav, icon `aria-hidden`, and a visually-hidden label so the bare number is not read out contextless.

## Verified in the browser

Drove a local stack in Chrome against INT data. Section position (directly above Trefwoorden), count-descending sort, linked vs plain-text names, NL→EN switch (names and hrefs both change, `/en` prefix applied), both negative cases (no themes; theme but no public license), real Tab-key navigation (link → link, skips the unlinked name, exits cleanly, visible focus ring), and 320px (no horizontal overflow, counter never splits from its icon).

4 component tests; 220 passed across the ie-objects module. Biome and stylelint clean.

## Known gaps, deliberately left

1. **The counter is not a link.** The FA wants it pointing at a theme-filtered search — that is ARC-3797, which depends on ARC-3796. There is no URL to link to yet, so it renders as plain text with a `TODO ARC-3797` at the spot that needs changing. Documented on the Jira ticket.
2. **Two translation keys must be added in meemoo admin (NL + EN)**, otherwise the section shows `Themas ***`:
   - `modules/ie-objects/components/object-detail-page-metadata/object-detail-page-metadata-themes___themas`
   - `modules/ie-objects/components/object-detail-page-metadata/object-detail-page-metadata-themes___aantal-objecten-in-dit-thema` (takes `{{count}}`)

## Two things for review

- **No media-type gate.** The FA says "AV object" and the search FA excludes kranten, but this only gates on licence. The newspaper `qsrf5kbg5k` on INT shows the section today. `AV_OBJECT_TYPES` is already available in `ObjectDetailPageMetadata.tsx` if we want it.
- **Focus ring is `solid 1px`** on theme links where neighbouring focusables use `2px`. Visible, just thinner — trivial to align if we care.


[ARC-3826]: https://meemoo.atlassian.net/browse/ARC-3826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ